### PR TITLE
🐛 fix: Remove underscore artifacts between README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,33 +15,19 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/isandrel/bookmark-scout/blob/main/LICENSE">
-    <img src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square" alt="License">
-  </a>
-  <a href="https://github.com/isandrel/bookmark-scout/stargazers">
-    <img src="https://img.shields.io/github/stars/isandrel/bookmark-scout?style=flat-square" alt="Stars">
-  </a>
-  <a href="https://github.com/isandrel/bookmark-scout/issues">
-    <img src="https://img.shields.io/github/issues/isandrel/bookmark-scout?style=flat-square" alt="Issues">
-  </a>
-  <a href="https://github.com/isandrel/bookmark-scout/pulls">
-    <img src="https://img.shields.io/github/issues-pr/isandrel/bookmark-scout?style=flat-square" alt="PRs">
-  </a>
+  <a href="https://github.com/isandrel/bookmark-scout/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue?style=flat-square" alt="License"></a>
+  <a href="https://github.com/isandrel/bookmark-scout/stargazers"><img src="https://img.shields.io/github/stars/isandrel/bookmark-scout?style=flat-square" alt="Stars"></a>
+  <a href="https://github.com/isandrel/bookmark-scout/issues"><img src="https://img.shields.io/github/issues/isandrel/bookmark-scout?style=flat-square" alt="Issues"></a>
+  <a href="https://github.com/isandrel/bookmark-scout/pulls"><img src="https://img.shields.io/github/issues-pr/isandrel/bookmark-scout?style=flat-square" alt="PRs"></a>
   <img src="https://img.shields.io/badge/manifest-v3-blue?style=flat-square" alt="Manifest V3">
 </p>
 
 <p align="center">
-  <a href="https://github.com/isandrel/bookmark-scout/actions/workflows/release-extension.yml">
-    <img src="https://img.shields.io/github/actions/workflow/status/isandrel/bookmark-scout/release-extension.yml?style=flat-square&label=build" alt="Build Status">
-  </a>
-  <a href="https://github.com/isandrel/bookmark-scout/releases">
-    <img src="https://img.shields.io/github/v/release/isandrel/bookmark-scout?style=flat-square" alt="Release">
-  </a>
+  <a href="https://github.com/isandrel/bookmark-scout/actions/workflows/release-extension.yml"><img src="https://img.shields.io/github/actions/workflow/status/isandrel/bookmark-scout/release-extension.yml?style=flat-square&label=build" alt="Build Status"></a>
+  <a href="https://github.com/isandrel/bookmark-scout/releases"><img src="https://img.shields.io/github/v/release/isandrel/bookmark-scout?style=flat-square" alt="Release"></a>
   <img src="https://img.shields.io/github/last-commit/isandrel/bookmark-scout?style=flat-square" alt="Last Commit">
   <img src="https://img.shields.io/github/repo-size/isandrel/bookmark-scout?style=flat-square" alt="Repo Size">
-  <a href="https://bookmark-scout.vercel.app">
-    <img src="https://img.shields.io/badge/website-live-brightgreen?style=flat-square" alt="Website">
-  </a>
+  <a href="https://bookmark-scout.vercel.app"><img src="https://img.shields.io/badge/website-live-brightgreen?style=flat-square" alt="Website"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
Fix visual underscore artifacts appearing between badges in README.

## Changes
- Inline badge HTML elements to eliminate whitespace between `<a>` and `<img>` tags
- Whitespace was being rendered as underlined text in GitHub's markdown renderer

Closes #16