### PR TITLE
🐛 fix: Resolve all lint errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,6 @@ jobs:
 
       - name: Run lint
         run: bun lint
-        continue-on-error: true  # TODO: Fix existing lint errors and remove this
 
   build:
     name: Build

--- a/src/components/bookmark/BookmarkItem.tsx
+++ b/src/components/bookmark/BookmarkItem.tsx
@@ -143,6 +143,7 @@ export function BookmarkItem({
         className="flex items-center flex-1 min-w-0 cursor-grab active:cursor-grabbing"
       >
         <img src={getFaviconUrl(node.url ?? '')} alt="favicon" className="w-4 h-4 mr-2 shrink-0" />
+        {/* biome-ignore lint/security/noDangerouslySetInnerHtml: Intentional for search highlighting */}
         <span className="truncate text-sm" dangerouslySetInnerHTML={{ __html: node.title }} />
       </a>
       <Button

--- a/src/components/bookmark/FolderItem.tsx
+++ b/src/components/bookmark/FolderItem.tsx
@@ -181,6 +181,7 @@ export function FolderItem({
             className="flex items-center flex-1 min-w-0 cursor-grab active:cursor-grabbing"
           >
             <Folder className="w-4 h-4 mr-2 shrink-0 text-muted-foreground" />
+            {/* biome-ignore lint/security/noDangerouslySetInnerHtml: Intentional for search highlighting */}
             <span className="truncate text-sm" dangerouslySetInnerHTML={{ __html: node.title }} />
           </div>
           <div className="flex items-center gap-1 ml-2 shrink-0 action-button">

--- a/src/components/bookmark/NewFolderInput.tsx
+++ b/src/components/bookmark/NewFolderInput.tsx
@@ -38,6 +38,8 @@ export function NewFolderInput({ value, onChange, onSubmit, onCancel }: NewFolde
   }, [value, onSubmit, onCancel]);
 
   return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: onClick used only for event bubbling control
+    // biome-ignore lint/a11y/noStaticElementInteractions: This div is a container, not interactive
     <div
       className="flex items-center gap-2 py-1 px-2 hover:bg-accent rounded-md folder-item"
       onClick={(e) => e.stopPropagation()}

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -32,6 +32,7 @@ export class ErrorBoundary extends Component<Props, State> {
               {this.state.error?.message || 'An unexpected error occurred'}
             </p>
             <button
+              type="button"
               className="px-4 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90"
               onClick={() => this.setState({ hasError: false })}
             >

--- a/src/components/page/BookmarksPage.tsx
+++ b/src/components/page/BookmarksPage.tsx
@@ -22,7 +22,7 @@ const formatDate = (timestamp?: number) => {
 
 const truncate = (text?: string, length = 50) => {
   if (!text) return '';
-  return text.length > length ? text.slice(0, length) + '...' : text;
+  return text.length > length ? `${text.slice(0, length)}...` : text;
 };
 
 const processNode = (node: chrome.bookmarks.BookmarkTreeNode, parentId = 'Root'): Bookmark => {
@@ -44,7 +44,7 @@ const processNode = (node: chrome.bookmarks.BookmarkTreeNode, parentId = 'Root')
 
 async function getTopLevelFolders(): Promise<Bookmark[]> {
   return new Promise((resolve) => {
-    if (chrome && chrome.bookmarks) {
+    if (chrome?.bookmarks) {
       chrome.bookmarks.getTree((nodes) => {
         // Filter out the root node and only process the actual top-level folders
         const topLevelFolders = nodes[0].children?.map((node) => processNode(node)) || [];
@@ -58,7 +58,7 @@ async function getTopLevelFolders(): Promise<Bookmark[]> {
 
 async function getFolderContents(folderId: string): Promise<Bookmark[]> {
   return new Promise((resolve) => {
-    if (chrome && chrome.bookmarks) {
+    if (chrome?.bookmarks) {
       chrome.bookmarks.getTree((nodes) => {
         // Find the target folder in the tree
         const findFolder = (
@@ -77,7 +77,7 @@ async function getFolderContents(folderId: string): Promise<Bookmark[]> {
         };
 
         const targetFolder = findFolder(nodes);
-        if (targetFolder && targetFolder.children) {
+        if (targetFolder?.children) {
           const contents = targetFolder.children.map((node) => processNode(node, folderId));
           resolve(contents);
         } else {
@@ -99,7 +99,7 @@ export const useParentIdMap = () => {
   const [parentIdMapState, setParentIdMap] = useState(parentIdMap);
 
   useEffect(() => {
-    if (chrome && chrome.bookmarks) {
+    if (chrome?.bookmarks) {
       chrome.bookmarks.getTree((nodes) => {
         const map: Record<
           string,
@@ -114,11 +114,15 @@ export const useParentIdMap = () => {
           };
 
           if (node.children) {
-            node.children.forEach((child) => processNode(child, node.id));
+            node.children.forEach((child) => {
+              processNode(child, node.id);
+            });
           }
         };
 
-        nodes.forEach((node) => processNode(node));
+        nodes.forEach((node) => {
+          processNode(node);
+        });
         setParentIdMap(map);
       });
     }
@@ -136,7 +140,7 @@ export const useUrlMap = () => {
   const [urlMapState, setUrlMap] = useState(urlMap);
 
   useEffect(() => {
-    if (chrome && chrome.bookmarks) {
+    if (chrome?.bookmarks) {
       chrome.bookmarks.getTree((nodes) => {
         const map: Record<
           string,
@@ -145,7 +149,9 @@ export const useUrlMap = () => {
 
         const processNode = (node: chrome.bookmarks.BookmarkTreeNode) => {
           if (node.children) {
-            node.children.forEach((child) => processNode(child));
+            node.children.forEach((child) => {
+              processNode(child);
+            });
           } else if (node.url) {
             const domain = new URL(node.url).hostname.split('.').slice(-2).join('.');
             map[domain] = {
@@ -156,7 +162,9 @@ export const useUrlMap = () => {
           }
         };
 
-        nodes.forEach((node) => processNode(node));
+        nodes.forEach((node) => {
+          processNode(node);
+        });
         setUrlMap(map);
       });
     }

--- a/src/components/page/PopupPage.tsx
+++ b/src/components/page/PopupPage.tsx
@@ -14,8 +14,8 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Toaster } from '@/components/ui/toaster';
 import { useDebounce } from '@/hooks/use-debounce';
-import { useToast } from '@/hooks/use-toast';
 import { t } from '@/hooks/use-i18n';
+import { useToast } from '@/hooks/use-toast';
 import { useBookmarkStore } from '@/stores';
 import type { BookmarkTreeNode, DragOperation } from '@/types';
 import '@/styles/popup.css';
@@ -162,7 +162,9 @@ function PopupPage() {
   if (error) {
     return (
       <div className="p-4">
-        <div className="text-red-500 mb-4">{t('error')}: {error}</div>
+        <div className="text-red-500 mb-4">
+          {t('error')}: {error}
+        </div>
         <Button onClick={() => window.location.reload()}>{t('retry')}</Button>
       </div>
     );
@@ -216,7 +218,11 @@ function PopupPage() {
                     }
                     onAddFolder={handleAddFolder}
                     onDeleteFolder={(id) =>
-                      withToast(() => removeFolder(id), t('folderDeleted'), t('errorDeletingFolder'))
+                      withToast(
+                        () => removeFolder(id),
+                        t('folderDeleted'),
+                        t('errorDeletingFolder'),
+                      )
                     }
                     onDeleteBookmark={(id) =>
                       withToast(

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -84,7 +84,7 @@ const SidebarProvider = React.forwardRef<
     // Helper to toggle the sidebar.
     const toggleSidebar = React.useCallback(() => {
       return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
-    }, [isMobile, setOpen, setOpenMobile]);
+    }, [isMobile, setOpen]);
 
     // Adds a keyboard shortcut to toggle the sidebar.
     React.useEffect(() => {
@@ -113,7 +113,7 @@ const SidebarProvider = React.forwardRef<
         setOpenMobile,
         toggleSidebar,
       }),
-      [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar],
+      [state, open, setOpen, isMobile, openMobile, toggleSidebar],
     );
 
     return (

--- a/src/components/ui/table/data-table-toolbar.tsx
+++ b/src/components/ui/table/data-table-toolbar.tsx
@@ -20,6 +20,10 @@ export function DataTableToolbar<TData>({ table, currentFolderId }: DataTableToo
   const isFiltered = table.getState().columnFilters.length > 0;
   const [applyToCurrentFolder, setApplyToCurrentFolder] = useState(false);
 
+  // Call hooks unconditionally at the top level
+  const parentIdOptions = Object.values(useParentIdMap());
+  const urlOptions = Object.values(useUrlMap());
+
   const handleApplyToCurrentFolderChange = (checked: boolean | 'indeterminate') => {
     setApplyToCurrentFolder(checked === true);
   };
@@ -79,14 +83,14 @@ export function DataTableToolbar<TData>({ table, currentFolderId }: DataTableToo
           <DataTableFacetedFilter
             column={table.getColumn('parentId')}
             title="Parent ID"
-            options={Object.values(useParentIdMap())}
+            options={parentIdOptions}
           />
         )}
         {table.getColumn('url') && (
           <DataTableFacetedFilter
             column={table.getColumn('url')}
             title="URL"
-            options={Object.values(useUrlMap())}
+            options={urlOptions}
           />
         )}
         {table.getColumn('url') && (

--- a/src/entrypoints/bookmarks/main.tsx
+++ b/src/entrypoints/bookmarks/main.tsx
@@ -7,15 +7,15 @@ import { ThemeProvider } from '@/components/theme-provider';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
-    throw new Error('Failed to find the root element');
+  throw new Error('Failed to find the root element');
 }
 
 createRoot(rootElement).render(
-    <StrictMode>
-        <ErrorBoundary>
-            <ThemeProvider defaultTheme="system" storageKey="bookmark-scout-theme">
-                <BookmarksPage />
-            </ThemeProvider>
-        </ErrorBoundary>
-    </StrictMode>,
+  <StrictMode>
+    <ErrorBoundary>
+      <ThemeProvider defaultTheme="system" storageKey="bookmark-scout-theme">
+        <BookmarksPage />
+      </ThemeProvider>
+    </ErrorBoundary>
+  </StrictMode>,
 );

--- a/src/entrypoints/options/main.tsx
+++ b/src/entrypoints/options/main.tsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import OptionsPage from '@/components/page/OptionsPage';
 
 createRoot(document.getElementById('root')!).render(
-    <StrictMode>
-        <OptionsPage />
-    </StrictMode>,
+  <StrictMode>
+    <OptionsPage />
+  </StrictMode>,
 );

--- a/src/entrypoints/popup/main.tsx
+++ b/src/entrypoints/popup/main.tsx
@@ -5,9 +5,9 @@ import { SidebarProvider } from '@/components/ui/sidebar';
 import '@/index.css';
 
 createRoot(document.getElementById('root')!).render(
-    <StrictMode>
-        <SidebarProvider>
-            <PopupPage />
-        </SidebarProvider>
-    </StrictMode>,
+  <StrictMode>
+    <SidebarProvider>
+      <PopupPage />
+    </SidebarProvider>
+  </StrictMode>,
 );

--- a/src/entrypoints/sidepanel/main.tsx
+++ b/src/entrypoints/sidepanel/main.tsx
@@ -6,9 +6,9 @@ import '@/index.css';
 
 // Sidepanel reuses the same PopupPage component
 createRoot(document.getElementById('root')!).render(
-    <StrictMode>
-        <SidebarProvider>
-            <PopupPage />
-        </SidebarProvider>
-    </StrictMode>,
+  <StrictMode>
+    <SidebarProvider>
+      <PopupPage />
+    </SidebarProvider>
+  </StrictMode>,
 );

--- a/src/hooks/use-bookmark-filter.ts
+++ b/src/hooks/use-bookmark-filter.ts
@@ -55,7 +55,7 @@ export function useBookmarkFilter(
           const filteredChildren = filterFolders(node.children, searchQuery);
 
           if (nodeMatches || filteredChildren.length > 0) {
-            let childrenToInclude;
+            let childrenToInclude: BookmarkTreeNode[];
             if (nodeMatches) {
               childrenToInclude = node.children.map((child) => {
                 if (

--- a/src/hooks/use-bookmark-operations.ts
+++ b/src/hooks/use-bookmark-operations.ts
@@ -43,7 +43,7 @@ export function useBookmarkOperations(onRefresh: () => Promise<void>): UseBookma
 
         const truncatedTitle = tab.title
           ? tab.title.length > 30
-            ? tab.title.slice(0, 30) + '...'
+            ? `${tab.title.slice(0, 30)}...`
             : tab.title
           : 'New Bookmark';
 
@@ -104,7 +104,7 @@ export function useBookmarkOperations(onRefresh: () => Promise<void>): UseBookma
 
         const truncatedTitle = bookmark.title
           ? bookmark.title.length > 30
-            ? bookmark.title.slice(0, 30) + '...'
+            ? `${bookmark.title.slice(0, 30)}...`
             : bookmark.title
           : 'Bookmark';
 
@@ -136,7 +136,7 @@ export function useBookmarkOperations(onRefresh: () => Promise<void>): UseBookma
 
         const truncatedTitle = folder.title
           ? folder.title.length > 30
-            ? folder.title.slice(0, 30) + '...'
+            ? `${folder.title.slice(0, 30)}...`
             : folder.title
           : 'Folder';
 

--- a/src/hooks/use-i18n.ts
+++ b/src/hooks/use-i18n.ts
@@ -5,42 +5,42 @@
 
 // Message keys available in messages.json
 export type MessageKey =
-    | 'extName'
-    | 'extDescription'
-    | 'searchPlaceholder'
-    | 'newFolder'
-    | 'retry'
-    | 'error'
-    | 'folderCreated'
-    | 'errorCreatingFolder'
-    | 'bookmarkAdded'
-    | 'errorAddingBookmark'
-    | 'bookmarkDeleted'
-    | 'errorDeletingBookmark'
-    | 'folderDeleted'
-    | 'errorDeletingFolder'
-    | 'itemMoved'
-    | 'errorMovingItem'
-    | 'addBookmark'
-    | 'addFolder'
-    | 'deleteFolder'
-    | 'deleteBookmark'
-    | 'expandAll'
-    | 'collapseAll'
-    | 'enterFolderName';
+  | 'extName'
+  | 'extDescription'
+  | 'searchPlaceholder'
+  | 'newFolder'
+  | 'retry'
+  | 'error'
+  | 'folderCreated'
+  | 'errorCreatingFolder'
+  | 'bookmarkAdded'
+  | 'errorAddingBookmark'
+  | 'bookmarkDeleted'
+  | 'errorDeletingBookmark'
+  | 'folderDeleted'
+  | 'errorDeletingFolder'
+  | 'itemMoved'
+  | 'errorMovingItem'
+  | 'addBookmark'
+  | 'addFolder'
+  | 'deleteFolder'
+  | 'deleteBookmark'
+  | 'expandAll'
+  | 'collapseAll'
+  | 'enterFolderName';
 
 /**
  * Get localized message from browser.i18n
  * Falls back to key if message not found
  */
 export function t(key: MessageKey, substitutions?: string | string[]): string {
-    try {
-        const message = browser.i18n.getMessage(key, substitutions);
-        return message || key;
-    } catch {
-        // Fallback for non-extension environments (like tests)
-        return key;
-    }
+  try {
+    const message = browser.i18n.getMessage(key, substitutions);
+    return message || key;
+  } catch {
+    // Fallback for non-extension environments (like tests)
+    return key;
+  }
 }
 
 /**
@@ -48,5 +48,5 @@ export function t(key: MessageKey, substitutions?: string | string[]): string {
  * Returns the t function for translations
  */
 export function useI18n() {
-    return { t };
+  return { t };
 }

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -174,7 +174,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,

--- a/src/services/bookmarks.ts
+++ b/src/services/bookmarks.ts
@@ -173,7 +173,7 @@ export async function getCurrentTab(): Promise<chrome.tabs.Tab> {
  */
 export function truncate(text?: string, length = 50): string {
   if (!text) return '';
-  return text.length > length ? text.slice(0, length) + '...' : text;
+  return text.length > length ? `${text.slice(0, length)}...` : text;
 }
 
 /**

--- a/src/stores/bookmark-store.ts
+++ b/src/stores/bookmark-store.ts
@@ -121,7 +121,7 @@ export const useBookmarkStore = create<BookmarkState>()(
 
           const truncatedTitle = tab.title
             ? tab.title.length > 30
-              ? tab.title.slice(0, 30) + '...'
+              ? `${tab.title.slice(0, 30)}...`
               : tab.title
             : 'New Bookmark';
 
@@ -158,7 +158,7 @@ export const useBookmarkStore = create<BookmarkState>()(
 
           const truncatedTitle = bookmark.title
             ? bookmark.title.length > 30
-              ? bookmark.title.slice(0, 30) + '...'
+              ? `${bookmark.title.slice(0, 30)}...`
               : bookmark.title
             : 'Bookmark';
 
@@ -177,7 +177,7 @@ export const useBookmarkStore = create<BookmarkState>()(
 
           const truncatedTitle = folder.title
             ? folder.title.length > 30
-              ? folder.title.slice(0, 30) + '...'
+              ? `${folder.title.slice(0, 30)}...`
               : folder.title
             : 'Folder';
 


### PR DESCRIPTION
## Summary
Fix all 12 lint errors to make CI lint step pass without `continue-on-error`.

## Changes
- Fix `useIterableCallbackReturn`: Wrap forEach callbacks in braces
- Fix `useHookAtTopLevel`: Move hooks to top level in data-table-toolbar.tsx
- Fix button type: Add `type="button"` to error-boundary.tsx
- Fix `noImplicitAnyLet`: Add type annotation in use-bookmark-filter.ts
- Add biome-ignore for `dangerouslySetInnerHTML` (intentional for search highlighting)
- Add biome-ignore for a11y in NewFolderInput (event bubbling control only)
- Remove `continue-on-error` from CI workflow

## Testing
- `bun lint` passes with exit code 0
- Only 11 warnings remain (performance suggestions, not blocking)

Closes #22