### PR TITLE
🐛 fix: remove hardcoded basePath for custom domain support

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -5,7 +5,8 @@ const withNextIntl = createNextIntlPlugin();
 
 const nextConfig: NextConfig = {
   output: "export",
-  basePath: "/bookmark-scout",
+  // Use /bookmark-scout for GitHub Pages, empty for custom domains
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH ?? "",
   images: { unoptimized: true },
   trailingSlash: true,
   turbopack: {


### PR DESCRIPTION
## Summary
Fixes 404 errors when using a custom domain with GitHub Pages.

## Changes
- Made `basePath` configurable via `NEXT_PUBLIC_BASE_PATH` environment variable
- Defaults to empty string (correct for custom domains)
- GitHub Pages workflow can set the env var if needed for subdirectory deployments

## Root Cause
`basePath: "/bookmark-scout"` was hardcoded, causing assets to load from wrong path on custom domain.

Closes #29