### PR TITLE
🐛 fix: update deploy-website paths for Nx monorepo

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'website/**'
+      - 'apps/website/**'
   workflow_dispatch:
 
 permissions:
@@ -33,18 +33,18 @@ jobs:
 
       - name: Install dependencies
         run: bun install
-        working-directory: ./website
+        working-directory: ./apps/website
 
       - name: Build with Next.js
         run: bun run build
-        working-directory: ./website
+        working-directory: ./apps/website
         env:
           NODE_ENV: production
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: ./website/out
+          path: ./apps/website/out
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary
Fixes website deployment after Nx monorepo migration.

## Changes
- `./website` → `./apps/website` for working directories
- `website/**` → `apps/website/**` for path trigger
- Updated artifact upload path

Closes #31