### PR TITLE
🐛 fix: remove turbopack.root config for CI compatibility

### DIFF
--- a/apps/website/next.config.ts
+++ b/apps/website/next.config.ts
@@ -9,9 +9,6 @@ const nextConfig: NextConfig = {
   basePath: process.env.NEXT_PUBLIC_BASE_PATH ?? "",
   images: { unoptimized: true },
   trailingSlash: true,
-  turbopack: {
-    root: ".",
-  },
 };
 
 export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Summary
Removes turbopack.root config that breaks CI builds.

## Changes
- Removed `turbopack.root: "."` from next.config.ts
- Let Next.js auto-detect workspace root

Closes #33