### PR TITLE
🔧 chore: add emoji to repomix workflow commit message

### DIFF
--- a/.github/workflows/repomix.yml
+++ b/.github/workflows/repomix.yml
@@ -41,5 +41,5 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add -f repomix-output.xml
-          git diff --staged --quiet || git commit -m "chore: update repomix-output.xml"
+          git diff --staged --quiet || git commit -m "🔧 chore: update repomix-output.xml"
           git push


### PR DESCRIPTION
Add gitmoji to repomix workflow commit message for consistency with project conventions.

Closes #37