### PR TITLE
📝 docs: fix build commands in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,11 @@ bun run dev
 ### Building
 
 ```bash
-# Build for Chrome
+# Build for all browsers
 bun run build
+
+# Build for Chrome
+bun run build:chrome
 
 # Build for Firefox
 bun run build:firefox


### PR DESCRIPTION
Fix build commands to clarify that `bun run build` builds all browsers.

Closes #41