### PR TITLE
🐛 fix: update URLs and asset paths for custom domain

### DIFF
--- a/apps/website/app/[locale]/layout.tsx
+++ b/apps/website/app/[locale]/layout.tsx
@@ -38,11 +38,11 @@ export async function generateMetadata({
             "drag and drop",
         ],
         alternates: {
-            canonical: `https://isandrel.github.io/bookmark-scout/${locale}`,
+            canonical: `https://bookmark-scout.com/${locale}`,
             languages: {
-                en: "https://isandrel.github.io/bookmark-scout/en",
-                ja: "https://isandrel.github.io/bookmark-scout/ja",
-                ko: "https://isandrel.github.io/bookmark-scout/ko",
+                en: "https://bookmark-scout.com/en",
+                ja: "https://bookmark-scout.com/ja",
+                ko: "https://bookmark-scout.com/ko",
             },
         },
         openGraph: {
@@ -50,10 +50,10 @@ export async function generateMetadata({
             description: metadata.description,
             type: "website",
             locale: locale === "ja" ? "ja_JP" : locale === "ko" ? "ko_KR" : "en_US",
-            url: `https://isandrel.github.io/bookmark-scout/${locale}`,
+            url: `https://bookmark-scout.com/${locale}`,
             images: [
                 {
-                    url: "/bookmark-scout/icon.png",
+                    url: "/icon.png",
                     width: 128,
                     height: 128,
                     alt: "Bookmark Scout",
@@ -64,7 +64,7 @@ export async function generateMetadata({
             card: "summary",
             title: "Bookmark Scout",
             description: metadata.description,
-            images: ["/bookmark-scout/icon.png"],
+            images: ["/icon.png"],
         },
     };
 }

--- a/apps/website/app/[locale]/page.tsx
+++ b/apps/website/app/[locale]/page.tsx
@@ -63,7 +63,7 @@ export default async function Home({
             <nav className="fixed top-0 left-0 right-0 z-50 glass">
                 <div className="mx-auto max-w-6xl px-6 py-4 flex items-center justify-between">
                     <div className="flex items-center gap-3">
-                        <img src="/bookmark-scout/icon.png" alt="Bookmark Scout" className="w-8 h-8" />
+                        <img src="/icon.png" alt="Bookmark Scout" className="w-8 h-8" />
                         <span className="font-bold text-lg">Bookmark Scout</span>
                     </div>
                     <div className="flex items-center gap-4">

--- a/apps/website/components/JsonLd.tsx
+++ b/apps/website/components/JsonLd.tsx
@@ -17,9 +17,9 @@ export function JsonLd() {
             name: "isandrel",
             url: "https://github.com/isandrel",
         },
-        url: "https://isandrel.github.io/bookmark-scout",
+        url: "https://bookmark-scout.com",
         downloadUrl: "https://github.com/isandrel/bookmark-scout",
-        screenshot: "https://isandrel.github.io/bookmark-scout/icon.png",
+        screenshot: "https://bookmark-scout.com/icon.png",
         softwareVersion: "0.1.0",
         aggregateRating: {
             "@type": "AggregateRating",


### PR DESCRIPTION
## Summary
Fix 404 errors for assets on bookmark-scout.com custom domain.

## Changes
- Update canonical/alternate URLs to use bookmark-scout.com instead of isandrel.github.io/bookmark-scout
- Remove /bookmark-scout/ prefix from asset paths (icon.png, manifest.json)
- Update structured data URLs in JsonLd component

Closes #43