### PR TITLE
💄 style(extension): add favicon to all extension pages

### DIFF
--- a/apps/extension/src/entrypoints/bookmarks/index.html
+++ b/apps/extension/src/entrypoints/bookmarks/index.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Bookmarks</title>
+    <title>Bookmark Scout - Bookmarks</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="/icon-32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/icon-16.png" />
 </head>
 
 <body>

--- a/apps/extension/src/entrypoints/options/index.html
+++ b/apps/extension/src/entrypoints/options/index.html
@@ -5,6 +5,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bookmark Scout - Options</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="/icon-32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/icon-16.png" />
     <meta name="manifest.open_in_tab" content="true" />
 </head>
 

--- a/apps/extension/src/entrypoints/popup/index.html
+++ b/apps/extension/src/entrypoints/popup/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bookmark Scout</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="/icon-32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/icon-16.png" />
     <style>
       html, body {
         margin: 0;

--- a/apps/extension/src/entrypoints/sidepanel/index.html
+++ b/apps/extension/src/entrypoints/sidepanel/index.html
@@ -5,6 +5,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Bookmark Scout - Side Panel</title>
+    <link rel="icon" type="image/png" sizes="32x32" href="/icon-32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/icon-16.png" />
     <style>
         html,
         body {


### PR DESCRIPTION
## Description
Add favicon link tags to all extension HTML pages so they display the Bookmark Scout icon instead of the default browser icon.

## Changes
- Added `<link rel="icon">` tags pointing to `/icon-32.png` and `/icon-16.png` in:
  - `popup/index.html`
  - `options/index.html`
  - `sidepanel/index.html`
  - `bookmarks/index.html`
- Updated bookmarks page title to "Bookmark Scout - Bookmarks" for consistency

## Type of Change
- [x] 💄 Style (UI/UX changes)

## Testing
- [x] Build passes for Chrome, Firefox, and Edge

Closes #67