### PR TITLE
💄 style(ci): add emoji to Dependabot commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "📦 chore(deps)"
     labels:
       - "dependencies"
       - "bun"
@@ -29,7 +29,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "📦 chore(deps)"
     labels:
       - "dependencies"
       - "bun"
@@ -42,7 +42,7 @@ updates:
     schedule:
       interval: "daily"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "📦 chore(deps)"
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## Description
Add 📦 emoji prefix to Dependabot commit messages to match the project's gitmoji convention.

## Changes
- Updated commit-message prefix from `chore(deps)` to `📦 chore(deps)` for all package ecosystems in dependabot.yml

## Type of Change
- [x] 💄 Style (formatting, no code change)

Closes #71