### PR TITLE
🐛 fix(ci): add continue-on-error to greetings workflow

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -10,6 +10,7 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/first-interaction@v3
+        continue-on-error: true
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: |


### PR DESCRIPTION
Prevents the workflow from failing for returning contributors where the first-interaction action has nothing to do.

Related to #80