### PR TITLE
🔧 fix(docs): static export for Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,4 +35,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy apps/docs/.next --project-name=bookmark-scout-docs
+          command: pages deploy apps/docs/out --project-name=bookmark-scout-docs

--- a/apps/docs/next.config.mjs
+++ b/apps/docs/next.config.mjs
@@ -5,6 +5,10 @@ const withMDX = createMDX();
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
+  output: 'export',
+  images: {
+    unoptimized: true,
+  },
 };
 
 export default withMDX(config);

--- a/apps/docs/src/app/api/search/route.ts
+++ b/apps/docs/src/app/api/search/route.ts
@@ -1,7 +1,0 @@
-import { source } from '@/lib/source';
-import { createFromSource } from 'fumadocs-core/search/server';
-
-export const { GET } = createFromSource(source, {
-  // https://docs.orama.com/docs/orama-js/supported-languages
-  language: 'english',
-});


### PR DESCRIPTION
Fix 404 on docs.bookmark-scout.com by configuring static export.

## Changes
- Add `output: 'export'` to next.config.mjs
- Remove /api/search route (incompatible with static export)
- Update deploy-docs.yml to deploy from `out` folder

Closes #91