### PR TITLE
♻️ refactor: redirect website /docs to external docs site

### DIFF
--- a/apps/website/app/[locale]/docs/page.tsx
+++ b/apps/website/app/[locale]/docs/page.tsx
@@ -1,7 +1,6 @@
-import Link from "next/link";
-import { getTranslations, setRequestLocale } from "next-intl/server";
-import { LanguageSwitcher } from "@/components/LanguageSwitcher";
-import { SITE_NAME, GITHUB_URL } from "@bookmark-scout/config";
+import { redirect } from "next/navigation";
+import { setRequestLocale } from "next-intl/server";
+import { DOCS_URL } from "@bookmark-scout/config";
 
 export default async function DocsPage({
     params,
@@ -10,73 +9,7 @@ export default async function DocsPage({
 }) {
     const { locale } = await params;
     setRequestLocale(locale);
-    const t = await getTranslations();
 
-    const docs = [
-        {
-            title: t("docs.gettingStarted.title"),
-            description: t("docs.gettingStarted.description"),
-            href: "getting-started",
-        },
-        {
-            title: t("docs.features.title"),
-            description: t("docs.features.description"),
-            href: "features",
-        },
-        {
-            title: t("docs.contributing.title"),
-            description: t("docs.contributing.description"),
-            href: "contributing",
-        },
-    ];
-
-    return (
-        <div className="min-h-screen bg-background">
-            {/* Navigation */}
-            <nav className="fixed top-0 left-0 right-0 z-50 glass">
-                <div className="mx-auto max-w-6xl px-6 py-4 flex items-center justify-between">
-                    <Link href={`/${locale}`} className="flex items-center gap-3">
-                        <span className="text-2xl">🔖</span>
-                        <span className="font-bold text-lg">{SITE_NAME}</span>
-                    </Link>
-                    <div className="flex items-center gap-4">
-                        <Link href={`/${locale}/docs`} className="text-foreground font-medium">
-                            {t("nav.docs")}
-                        </Link>
-                        <a
-                            href={GITHUB_URL}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="flex items-center gap-2 rounded-full bg-white/10 px-4 py-2 text-sm hover:bg-white/20 transition-colors"
-                        >
-                            {t("nav.github")}
-                        </a>
-                        <LanguageSwitcher currentLocale={locale} />
-                    </div>
-                </div>
-            </nav>
-
-            <main className="pt-32 pb-24">
-                <div className="mx-auto max-w-4xl px-6">
-                    <h1 className="text-4xl font-bold mb-4">{t("docs.title")}</h1>
-                    <p className="text-muted text-lg mb-12">{t("docs.subtitle")}</p>
-
-                    <div className="grid gap-6">
-                        {docs.map((doc) => (
-                            <Link
-                                key={doc.href}
-                                href={`/${locale}/docs/${doc.href}`}
-                                className="group p-6 rounded-2xl bg-card border border-card-border hover:border-primary/50 transition-all"
-                            >
-                                <h2 className="text-xl font-semibold mb-2 group-hover:text-primary-light transition-colors">
-                                    {doc.title}
-                                </h2>
-                                <p className="text-muted">{doc.description}</p>
-                            </Link>
-                        ))}
-                    </div>
-                </div>
-            </main>
-        </div>
-    );
+    // Redirect to external docs site
+    redirect(DOCS_URL);
 }

--- a/apps/website/app/[locale]/page.tsx
+++ b/apps/website/app/[locale]/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { getTranslations, setRequestLocale } from "next-intl/server";
 import { LanguageSwitcher } from "@/components/LanguageSwitcher";
-import { SITE_NAME, GITHUB_URL, AUTHOR } from "@bookmark-scout/config";
+import { SITE_NAME, GITHUB_URL, AUTHOR, DOCS_URL } from "@bookmark-scout/config";
 
 // Tech stack badges
 const techStack = [
@@ -69,7 +69,7 @@ export default async function Home({
                     </div>
                     <div className="flex items-center gap-4">
                         <Link
-                            href={`/${locale}/docs`}
+                            href={DOCS_URL}
                             className="text-muted hover:text-foreground transition-colors"
                         >
                             {t("nav.docs")}
@@ -142,7 +142,7 @@ export default async function Home({
                             </svg>
                         </a>
                         <Link
-                            href={`/${locale}/docs`}
+                            href={DOCS_URL}
                             className="rounded-full border border-white/20 px-8 py-4 font-medium hover:bg-white/5 transition-colors"
                         >
                             {t("hero.documentation")}

--- a/apps/website/app/sitemap.ts
+++ b/apps/website/app/sitemap.ts
@@ -4,13 +4,8 @@ import { SITE_URL, LOCALES } from "@bookmark-scout/config";
 export const dynamic = "force-static";
 
 export default function sitemap(): MetadataRoute.Sitemap {
-    const routes = [
-        "",
-        "/docs",
-        "/docs/getting-started",
-        "/docs/features",
-        "/docs/contributing",
-    ];
+    // Only include main landing page - docs are on docs.bookmark-scout.com
+    const routes = [""];
 
     const sitemap: MetadataRoute.Sitemap = [];
 
@@ -19,8 +14,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
             sitemap.push({
                 url: `${SITE_URL}/${locale}${route}`,
                 lastModified: new Date(),
-                changeFrequency: route === "" ? "weekly" : "monthly",
-                priority: route === "" ? 1 : 0.8,
+                changeFrequency: "weekly",
+                priority: 1,
             });
         }
     }


### PR DESCRIPTION
Redirect website /docs to docs.bookmark-scout.com.

## Changes
- /docs page now redirects to docs.bookmark-scout.com
- Sitemap only includes home page (docs are on separate site)
- Nav links now point directly to DOCS_URL

Closes #101