### PR TITLE
✨ feat(analytics): add Umami Cloud analytics to website

### DIFF
--- a/apps/website/app/[locale]/layout.tsx
+++ b/apps/website/app/[locale]/layout.tsx
@@ -1,10 +1,17 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import { Inter } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, setRequestLocale } from "next-intl/server";
 import { routing } from "@/i18n/routing";
 import { JsonLd } from "@/components/JsonLd";
-import { SITE_URL, SITE_NAME } from "@bookmark-scout/config";
+import {
+    SITE_URL,
+    SITE_NAME,
+    UMAMI_ENABLED,
+    UMAMI_WEBSITE_ID,
+    UMAMI_SCRIPT_URL,
+} from "@bookmark-scout/config";
 import "../globals.css";
 
 const inter = Inter({
@@ -85,6 +92,14 @@ export default async function LocaleLayout({
     return (
         <html lang={locale} className="dark">
             <head>
+                {UMAMI_ENABLED && (
+                    <Script
+                        defer
+                        src={UMAMI_SCRIPT_URL}
+                        data-website-id={UMAMI_WEBSITE_ID}
+                        strategy="afterInteractive"
+                    />
+                )}
                 <JsonLd />
             </head>
             <body className={`${inter.variable} font-sans antialiased`}>

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -1,10 +1,14 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import { Inter } from "next/font/google";
 import {
     SITE_URL,
     SITE_NAME,
     SITE_DESCRIPTION,
     AUTHOR,
+    UMAMI_ENABLED,
+    UMAMI_WEBSITE_ID,
+    UMAMI_SCRIPT_URL,
 } from "@bookmark-scout/config";
 import "./globals.css";
 
@@ -84,6 +88,16 @@ export default function RootLayout({
 }>) {
     return (
         <html lang="en" className="dark">
+            <head>
+                {UMAMI_ENABLED && (
+                    <Script
+                        defer
+                        src={UMAMI_SCRIPT_URL}
+                        data-website-id={UMAMI_WEBSITE_ID}
+                        strategy="afterInteractive"
+                    />
+                )}
+            </head>
             <body className={`${inter.variable} font-sans antialiased`}>
                 {children}
             </body>

--- a/config/site.config.toml
+++ b/config/site.config.toml
@@ -3,21 +3,41 @@
 # Change these values to update the domain/settings across the entire project.
 
 [site]
-name = "Bookmark Scout"
-url = "https://bookmark-scout.com"
 description = "A modern Chrome extension to quickly search, organize, and save bookmarks to specific folders. Features drag-and-drop, instant search, dark mode, and side panel support."
+name        = "Bookmark Scout"
+url         = "https://bookmark-scout.com"
 
 [author]
 name = "isandrel"
-url = "https://github.com/isandrel"
+url  = "https://github.com/isandrel"
 
 [github]
 url = "https://github.com/isandrel/bookmark-scout"
 
 [locales]
+default   = "en"
 supported = ["en", "ja", "ko"]
-default = "en"
 
 [docs]
 name = "Bookmark Scout Docs"
-url = "https://docs.bookmark-scout.com"
+url  = "https://docs.bookmark-scout.com"
+
+# =============================================================================
+# Analytics (Umami Cloud)
+# Each site has its own analytics configuration
+# =============================================================================
+
+# Analytics for bookmark-scout.com (main website)
+[analytics.website]
+enabled    = true
+provider   = "umami"
+script_url = "https://cloud.umami.is/script.js"
+website_id = "878e552a-c74d-4ebf-b101-398993c55023"
+
+# Analytics for docs.bookmark-scout.com
+# Uncomment and configure when ready
+# [analytics.docs]
+# enabled    = false
+# provider   = "umami"
+# script_url = "https://cloud.umami.is/script.js"
+# website_id = ""

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -21,60 +21,74 @@ const __dirname = dirname(__filename);
  * Site configuration schema
  */
 export interface SiteConfig {
-    site: {
-        name: string;
-        url: string;
-        description: string;
-    };
-    author: {
-        name: string;
-        url: string;
-    };
-    github: {
-        url: string;
-    };
-    locales: {
-        supported: string[];
-        default: string;
-    };
-    docs: {
-        name: string;
-        url: string;
-    };
+	site: {
+		name: string;
+		url: string;
+		description: string;
+	};
+	author: {
+		name: string;
+		url: string;
+	};
+	github: {
+		url: string;
+	};
+	locales: {
+		supported: string[];
+		default: string;
+	};
+	docs: {
+		name: string;
+		url: string;
+	};
+	analytics?: {
+		website?: {
+			enabled: boolean;
+			provider: string;
+			website_id: string;
+			script_url: string;
+		};
+		docs?: {
+			enabled: boolean;
+			provider: string;
+			website_id: string;
+			script_url: string;
+		};
+	};
 }
 
 /**
  * Find and read the config file from multiple possible locations
  */
 function findConfigFile(): string {
-    // Try multiple paths to find the config file
-    const possiblePaths = [
-        // From packages/config/src (development)
-        resolve(__dirname, "../../../config/site.config.toml"),
-        // From packages/config (built)
-        resolve(__dirname, "../../config/site.config.toml"),
-        // From apps/website (Next.js)
-        resolve(process.cwd(), "../../config/site.config.toml"),
-        // From apps/extension (WXT)
-        resolve(process.cwd(), "../../config/site.config.toml"),
-        // From monorepo root
-        resolve(process.cwd(), "config/site.config.toml"),
-    ];
+	// Try multiple paths to find the config file
+	const possiblePaths = [
+		// From packages/config/src (development)
+		resolve(__dirname, "../../../config/site.config.toml"),
+		// From packages/config (built)
+		resolve(__dirname, "../../config/site.config.toml"),
+		// From apps/website (Next.js)
+		resolve(process.cwd(), "../../config/site.config.toml"),
+		// From apps/extension (WXT)
+		resolve(process.cwd(), "../../config/site.config.toml"),
+		// From monorepo root
+		resolve(process.cwd(), "config/site.config.toml"),
+	];
 
-    for (const configPath of possiblePaths) {
-        try {
-            const content = readFileSync(configPath, "utf-8");
-            return content;
-        } catch {
-            // Try next path
-        }
-    }
+	for (const configPath of possiblePaths) {
+		try {
+			const content = readFileSync(configPath, "utf-8");
+			return content;
+		} catch {
+			// Try next path
+		}
+	}
 
-    throw new Error(
-        `Failed to read site configuration. ` +
-        `Make sure config/site.config.toml exists at the monorepo root. ` +
-        `Searched paths:\n${possiblePaths.map((p) => `  - ${p}`).join("\n")}`
-    );
+	throw new Error(
+		`Failed to read site configuration. ` +
+			`Make sure config/site.config.toml exists at the monorepo root. ` +
+			`Searched paths:\n${possiblePaths.map((p) => `  - ${p}`).join("\n")}`,
+	);
 }
 
 // Parse the config file
@@ -83,16 +97,16 @@ const config = parse(tomlContent) as unknown as SiteConfig;
 
 // Validate required fields
 if (!config.site?.name) {
-    throw new Error("config/site.config.toml: site.name is required");
+	throw new Error("config/site.config.toml: site.name is required");
 }
 if (!config.site?.url) {
-    throw new Error("config/site.config.toml: site.url is required");
+	throw new Error("config/site.config.toml: site.url is required");
 }
 if (!config.author?.name) {
-    throw new Error("config/site.config.toml: author.name is required");
+	throw new Error("config/site.config.toml: author.name is required");
 }
 if (!config.github?.url) {
-    throw new Error("config/site.config.toml: github.url is required");
+	throw new Error("config/site.config.toml: github.url is required");
 }
 
 // ============================================================================
@@ -131,3 +145,32 @@ export const DOCS_NAME = config.docs?.name ?? "Docs";
 
 /** Docs site URL */
 export const DOCS_URL = config.docs?.url ?? "https://docs.bookmark-scout.com";
+
+// ============================================================================
+// Analytics Configuration
+// ============================================================================
+
+/** Analytics config for main website (bookmark-scout.com) */
+export const ANALYTICS_WEBSITE = config.analytics?.website ?? {
+	enabled: false,
+	provider: "umami",
+	website_id: "",
+	script_url: "",
+};
+
+/** Whether website analytics is enabled */
+export const UMAMI_ENABLED = ANALYTICS_WEBSITE.enabled;
+
+/** Umami website ID for main website */
+export const UMAMI_WEBSITE_ID = ANALYTICS_WEBSITE.website_id;
+
+/** Umami script URL */
+export const UMAMI_SCRIPT_URL = ANALYTICS_WEBSITE.script_url;
+
+/** Analytics config for docs site (docs.bookmark-scout.com) */
+export const ANALYTICS_DOCS = config.analytics?.docs ?? {
+	enabled: false,
+	provider: "umami",
+	website_id: "",
+	script_url: "",
+};


### PR DESCRIPTION
## Description
Integrates Umami Cloud analytics to track visitor behavior on bookmark-scout.com.

## Changes
- Add `[analytics.website]` section to `site.config.toml` with Umami configuration
- Export `UMAMI_ENABLED`, `UMAMI_WEBSITE_ID`, `UMAMI_SCRIPT_URL` from config package
- Add tracking script to root and locale layouts with conditional rendering
- Include placeholder for docs site analytics configuration

## Type of Change
- [x] New feature

## Testing
- TypeScript compiles successfully
- Configuration values properly exported

Closes #107