### PR TITLE
🐛 fix(ci): skip greetings for bot accounts

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -5,6 +5,8 @@ on: [pull_request_target, issues]
 jobs:
   greeting:
     runs-on: ubuntu-latest
+    # Skip greeting for bot accounts
+    if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
     permissions:
       issues: write
       pull-requests: write


### PR DESCRIPTION
Closes #112

## Description
The greetings workflow was sending welcome messages to bot accounts (dependabot, github-actions). Added condition to skip bot actors.

## Type of Change
- [x] Bug fix