### PR TITLE
🔧 chore(ci): disable automatic repomix workflow

### DIFF
--- a/.github/workflows/repomix.yml
+++ b/.github/workflows/repomix.yml
@@ -1,11 +1,12 @@
 name: Generate Repomix Output
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-  workflow_dispatch: # Allow manual trigger
+  # Disabled automatic triggers - CI doesn't run on PRs created by GITHUB_TOKEN
+  # push:
+  #   branches: [main]
+  # pull_request:
+  #   branches: [main]
+  workflow_dispatch: # Manual trigger only
 
 permissions:
   contents: write


### PR DESCRIPTION
Closes #115

## Description
Disabled automatic push/pull_request triggers for repomix workflow. Only manual workflow_dispatch remains.

## Reason
PRs created by GITHUB_TOKEN don't trigger CI workflows, causing required checks to never run.