### PR TITLE
🔧 chore(ci): use PAT for update-readme workflow

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   generate:
@@ -29,16 +30,20 @@ jobs:
       - name: Generate README files
         run: bun run generate:readme
 
-      - name: Check for changes
-        id: changes
-        run: |
-          git diff --quiet README.md translations/ || echo "has_changes=true" >> $GITHUB_OUTPUT
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          # Use PAT to trigger CI on created PRs (GITHUB_TOKEN doesn't trigger workflows)
+          token: ${{ secrets.PAT_GITHUB }}
+          commit-message: '📝 docs: update README from templates'
+          title: '📝 docs: update README from templates'
+          body: |
+            This PR updates README files generated from templates.
 
-      - name: Commit and push changes
-        if: steps.changes.outputs.has_changes == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md translations/
-          git commit -m "📝 docs: update README from templates"
-          git push
+            Triggered by changes to:
+            - `config/site.config.toml`
+            - `templates/**`
+            - `scripts/generate-readme.ts`
+          branch: auto/update-readme
+          delete-branch: true
+          labels: documentation


### PR DESCRIPTION
Closes #119

## Description
Use Personal Access Token (PAT_GITHUB) instead of GITHUB_TOKEN so created PRs trigger CI workflows.

## Required Setup
Add `PAT_GITHUB` secret to repository with:
- Contents: Read and write
- Pull requests: Read and write