### PR TITLE
🔧 chore(ci): use secret for Cloudflare project name

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,4 +35,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy apps/docs/out --project-name=bookmark-scout-docs
+          command: pages deploy apps/docs/out --project-name=${{ secrets.CLOUDFLARE_PROJECT_NAME_DOCS }}


### PR DESCRIPTION
Closes #125

Use CLOUDFLARE_PROJECT_NAME_DOCS secret instead of hardcoded project name.

## Required Setup
Add `CLOUDFLARE_PROJECT_NAME_DOCS` secret with value `bookmark-scout-docs`