### PR TITLE
🐛 fix: use single source for meta title

### DIFF
--- a/apps/website/app/[locale]/layout.tsx
+++ b/apps/website/app/[locale]/layout.tsx
@@ -8,6 +8,8 @@ import { JsonLd } from "@/components/JsonLd";
 import {
     SITE_URL,
     SITE_NAME,
+    SITE_META_TITLE,
+    SITE_DESCRIPTION,
     UMAMI_ENABLED,
     UMAMI_WEBSITE_ID,
     UMAMI_SCRIPT_URL,
@@ -29,12 +31,11 @@ export async function generateMetadata({
     params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
     const { locale } = await params;
-    const messages = await getMessages();
-    const metadata = messages.metadata as { title: string; description: string };
+    await getMessages();
 
     return {
-        title: metadata.title,
-        description: metadata.description,
+        title: `${SITE_NAME} | ${SITE_META_TITLE}`,
+        description: SITE_DESCRIPTION,
         keywords: [
             "chrome extension",
             "bookmarks",
@@ -55,7 +56,7 @@ export async function generateMetadata({
         },
         openGraph: {
             title: SITE_NAME,
-            description: metadata.description,
+            description: SITE_DESCRIPTION,
             type: "website",
             locale: locale === "ja" ? "ja_JP" : locale === "ko" ? "ko_KR" : "en_US",
             url: `${SITE_URL}/${locale}`,
@@ -71,7 +72,7 @@ export async function generateMetadata({
         twitter: {
             card: "summary",
             title: SITE_NAME,
-            description: metadata.description,
+            description: SITE_DESCRIPTION,
             images: ["/icon.png"],
         },
     };

--- a/apps/website/app/layout.tsx
+++ b/apps/website/app/layout.tsx
@@ -5,6 +5,7 @@ import {
     SITE_URL,
     SITE_NAME,
     SITE_DESCRIPTION,
+    SITE_META_TITLE,
     AUTHOR,
     UMAMI_ENABLED,
     UMAMI_WEBSITE_ID,
@@ -20,7 +21,7 @@ const inter = Inter({
 export const metadata: Metadata = {
     metadataBase: new URL(SITE_URL),
     title: {
-        default: `${SITE_NAME} | Browser Bookmark Manager`,
+        default: `${SITE_NAME} | ${SITE_META_TITLE}`,
         template: `%s | ${SITE_NAME}`,
     },
     description: SITE_DESCRIPTION,
@@ -46,7 +47,7 @@ export const metadata: Metadata = {
         alternateLocale: ["ja_JP", "ko_KR"],
         url: SITE_URL,
         siteName: SITE_NAME,
-        title: `${SITE_NAME} | Browser Bookmark Manager`,
+        title: `${SITE_NAME} | ${SITE_META_TITLE}`,
         description: SITE_DESCRIPTION,
         images: [
             {
@@ -59,7 +60,7 @@ export const metadata: Metadata = {
     },
     twitter: {
         card: "summary",
-        title: `${SITE_NAME} | Browser Bookmark Manager`,
+        title: `${SITE_NAME} | ${SITE_META_TITLE}`,
         description: SITE_DESCRIPTION,
         images: ["/icon.png"],
     },

--- a/config/site.config.toml
+++ b/config/site.config.toml
@@ -3,7 +3,8 @@
 # Change these values to update the domain/settings across the entire project.
 
 [site]
-description = "A modern Chrome extension to quickly search, organize, and save bookmarks to specific folders. Features drag-and-drop, instant search, dark mode, and side panel support."
+description = "A modern browser extension to quickly search, organize, and save bookmarks to specific folders. Features drag-and-drop, instant search, dark mode, and side panel support."
+meta_title  = "Browser Bookmark Manager"
 name        = "Bookmark Scout"
 url         = "https://bookmark-scout.com"
 

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -23,6 +23,7 @@ const __dirname = dirname(__filename);
 export interface SiteConfig {
 	site: {
 		name: string;
+		meta_title: string;
 		url: string;
 		description: string;
 	};
@@ -124,6 +125,9 @@ export const SITE_URL = config.site.url;
 
 /** Site description */
 export const SITE_DESCRIPTION = config.site.description;
+
+/** Site meta title for SEO (short version without site name) */
+export const SITE_META_TITLE = config.site.meta_title;
 
 /** Author information */
 export const AUTHOR = config.author;


### PR DESCRIPTION
Closes #127

## Changes
- Added `meta_title` field to `site.config.toml` as single source of truth
- Export `SITE_META_TITLE` from `@bookmark-scout/config`
- Updated `apps/website/app/layout.tsx` to use config values
- Updated `apps/website/app/[locale]/layout.tsx` to use config values
- Changed 'Chrome' to 'browser' in description for browser-agnostic messaging

## Result
Meta title is now: "Bookmark Scout | Browser Bookmark Manager" (47 chars, under 60)