### PR TITLE
🐛 fix: shorten meta description for SEO

### DIFF
--- a/config/site.config.toml
+++ b/config/site.config.toml
@@ -3,7 +3,7 @@
 # Change these values to update the domain/settings across the entire project.
 
 [site]
-description = "A modern browser extension to quickly search, organize, and save bookmarks to specific folders. Features drag-and-drop, instant search, dark mode, and side panel support."
+description = "A browser extension to quickly search, organize, and save bookmarks. Features drag-and-drop, instant search, and dark mode."
 meta_title  = "Browser Bookmark Manager"
 name        = "Bookmark Scout"
 url         = "https://bookmark-scout.com"


### PR DESCRIPTION
Closes #130

Reduced description from 170 to 124 chars (optimal: 70-155).