### PR TITLE
💄 style(popup): add subtle scale effect on hover for items

### DIFF
--- a/apps/extension/src/components/bookmark/BookmarkItem.tsx
+++ b/apps/extension/src/components/bookmark/BookmarkItem.tsx
@@ -130,7 +130,7 @@ export function BookmarkItem({
 
   return (
     <div
-      className={`group flex items-center justify-between h-8 py-1 px-2 hover:bg-accent rounded-md transition-colors bookmark-item ${isDragging ? 'opacity-50' : ''}`}
+      className={`group flex items-center justify-between h-8 py-1 px-2 hover:bg-accent rounded-md transition-all duration-150 hover:scale-[1.01] origin-left bookmark-item ${isDragging ? 'opacity-50' : ''}`}
     >
       <a
         ref={(el) => {

--- a/apps/extension/src/components/bookmark/FolderItem.tsx
+++ b/apps/extension/src/components/bookmark/FolderItem.tsx
@@ -174,7 +174,7 @@ export function FolderItem({
       value={node.id}
       className={`border-none accordion-item ${isDragging ? 'opacity-50' : ''}`}
     >
-      <AccordionTrigger className="group hover:no-underline py-1 px-2 hover:bg-accent rounded-md h-8 folder-item transition-colors">
+      <AccordionTrigger className="group hover:no-underline py-1 px-2 hover:bg-accent rounded-md h-8 folder-item transition-all duration-150 hover:scale-[1.01] origin-left">
         <div className="flex items-center w-full">
           <div
             ref={(el) => {


### PR DESCRIPTION
## Summary
Add subtle visual feedback when hovering over items in the popup.

## Changes
- Add `hover:scale-[1.01]` to FolderItem and BookmarkItem
- Use `origin-left` for natural left-anchored scaling
- Use `transition-all duration-150` for smooth animation

Closes #140