### PR TITLE
🐛 fix(popup): remove horizontal bar and add tooltips on hover

### DIFF
--- a/apps/extension/src/components/bookmark/BookmarkItem.tsx
+++ b/apps/extension/src/components/bookmark/BookmarkItem.tsx
@@ -144,7 +144,7 @@ export function BookmarkItem({
       >
         <img src={getFaviconUrl(node.url ?? '')} alt="" className="w-4 h-4 mr-2 shrink-0 rounded-sm" />
         {/* biome-ignore lint/security/noDangerouslySetInnerHtml: Intentional for search highlighting */}
-        <span className="truncate text-sm" dangerouslySetInnerHTML={{ __html: node.title }} />
+        <span className="truncate text-sm" title={node.title.replace(/<[^>]*>/g, '')} dangerouslySetInnerHTML={{ __html: node.title }} />
       </a>
       <Button
         variant="ghost"

--- a/apps/extension/src/components/bookmark/FolderItem.tsx
+++ b/apps/extension/src/components/bookmark/FolderItem.tsx
@@ -185,7 +185,7 @@ export function FolderItem({
           >
             <Folder className="w-4 h-4 mr-2 shrink-0 text-amber-500 dark:text-amber-400" />
             {/* biome-ignore lint/security/noDangerouslySetInnerHtml: Intentional for search highlighting */}
-            <span className="truncate text-sm" dangerouslySetInnerHTML={{ __html: node.title }} />
+            <span className="truncate text-sm" title={node.title.replace(/<[^>]*>/g, '')} dangerouslySetInnerHTML={{ __html: node.title }} />
             {itemCount > 0 && (
               <span className="ml-2 text-xs text-muted-foreground tabular-nums">
                 ({itemCount})

--- a/apps/extension/src/components/ui/accordion.tsx
+++ b/apps/extension/src/components/ui/accordion.tsx
@@ -10,7 +10,7 @@ const AccordionItem = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Item>
 >(({ className, ...props }, ref) => (
-  <AccordionPrimitive.Item ref={ref} className={cn('border-b', className)} {...props} />
+  <AccordionPrimitive.Item ref={ref} className={cn(className)} {...props} />
 ));
 AccordionItem.displayName = 'AccordionItem';
 


### PR DESCRIPTION
## Summary
Fix two UI issues in the popup.

## Changes
1. **Remove horizontal bar** - Removed `border-b` from AccordionItem that was causing unwanted horizontal line below folders
2. **Add tooltips** - Added native `title` attribute to folder and bookmark name spans for tooltip on hover

Closes #142