### PR TITLE
🌐 feat(i18n): add i18n support for popup and options pages

### DIFF
--- a/apps/extension/public/_locales/en/messages.json
+++ b/apps/extension/public/_locales/en/messages.json
@@ -90,5 +90,117 @@
     "enterFolderName": {
         "message": "Enter folder name...",
         "description": "New folder input placeholder"
+    },
+    "noBookmarksFound": {
+        "message": "No bookmarks found",
+        "description": "Empty state when search has no results"
+    },
+    "noBookmarksYet": {
+        "message": "No bookmarks yet",
+        "description": "Empty state when there are no bookmarks"
+    },
+    "tryDifferentSearch": {
+        "message": "Try a different search term",
+        "description": "Hint for empty search results"
+    },
+    "lightMode": {
+        "message": "Light mode",
+        "description": "Light mode toggle tooltip"
+    },
+    "darkMode": {
+        "message": "Dark mode",
+        "description": "Dark mode toggle tooltip"
+    },
+    "settings": {
+        "message": "Settings",
+        "description": "Settings page title"
+    },
+    "settingsDescription": {
+        "message": "Customize your Bookmark Scout experience",
+        "description": "Settings page description"
+    },
+    "searchSettings": {
+        "message": "Search settings...",
+        "description": "Settings search placeholder"
+    },
+    "loadingSettings": {
+        "message": "Loading settings...",
+        "description": "Settings loading state"
+    },
+    "noSettingsMatch": {
+        "message": "No settings match your search in this category.",
+        "description": "Empty settings search result"
+    },
+    "settingsSaved": {
+        "message": "Settings saved",
+        "description": "Toast title for settings save success"
+    },
+    "preferencesUpdated": {
+        "message": "Your preferences have been updated.",
+        "description": "Toast description for settings save success"
+    },
+    "errorSavingSettings": {
+        "message": "Error saving settings",
+        "description": "Toast title for settings save error"
+    },
+    "settingsReset": {
+        "message": "Settings reset",
+        "description": "Toast title for settings reset success"
+    },
+    "settingsResetDescription": {
+        "message": "All settings have been restored to defaults.",
+        "description": "Toast description for settings reset success"
+    },
+    "errorResettingSettings": {
+        "message": "Error resetting settings",
+        "description": "Toast title for settings reset error"
+    },
+    "settingsExported": {
+        "message": "Settings exported",
+        "description": "Toast title for settings export success"
+    },
+    "settingsExportedDescription": {
+        "message": "Settings file has been downloaded.",
+        "description": "Toast description for settings export success"
+    },
+    "exportFailed": {
+        "message": "Export failed",
+        "description": "Toast title for settings export error"
+    },
+    "settingsImported": {
+        "message": "Settings imported",
+        "description": "Toast title for settings import success"
+    },
+    "settingsImportedDescription": {
+        "message": "Your settings have been restored from file.",
+        "description": "Toast description for settings import success"
+    },
+    "importFailed": {
+        "message": "Import failed",
+        "description": "Toast title for settings import error"
+    },
+    "invalidSettingsFile": {
+        "message": "Invalid settings file",
+        "description": "Error message for invalid settings import"
+    },
+    "export": {
+        "message": "Export",
+        "description": "Export button label"
+    },
+    "import": {
+        "message": "Import",
+        "description": "Import button label"
+    },
+    "resetAll": {
+        "message": "Reset All",
+        "description": "Reset all settings button label"
+    },
+    "saving": {
+        "message": "Saving...",
+        "description": "Saving state button label"
+    },
+    "saveChanges": {
+        "message": "Save Changes",
+        "description": "Save changes button label"
     }
 }

--- a/apps/extension/public/_locales/ja/messages.json
+++ b/apps/extension/public/_locales/ja/messages.json
@@ -90,5 +90,117 @@
     "enterFolderName": {
         "message": "フォルダ名を入力...",
         "description": "New folder input placeholder"
+    },
+    "noBookmarksFound": {
+        "message": "ブックマークが見つかりません",
+        "description": "Empty state when search has no results"
+    },
+    "noBookmarksYet": {
+        "message": "ブックマークはまだありません",
+        "description": "Empty state when there are no bookmarks"
+    },
+    "tryDifferentSearch": {
+        "message": "別の検索ワードをお試しください",
+        "description": "Hint for empty search results"
+    },
+    "lightMode": {
+        "message": "ライトモード",
+        "description": "Light mode toggle tooltip"
+    },
+    "darkMode": {
+        "message": "ダークモード",
+        "description": "Dark mode toggle tooltip"
+    },
+    "settings": {
+        "message": "設定",
+        "description": "Settings page title"
+    },
+    "settingsDescription": {
+        "message": "Bookmark Scoutをカスタマイズ",
+        "description": "Settings page description"
+    },
+    "searchSettings": {
+        "message": "設定を検索...",
+        "description": "Settings search placeholder"
+    },
+    "loadingSettings": {
+        "message": "設定を読み込み中...",
+        "description": "Settings loading state"
+    },
+    "noSettingsMatch": {
+        "message": "このカテゴリには一致する設定がありません",
+        "description": "Empty settings search result"
+    },
+    "settingsSaved": {
+        "message": "設定を保存しました",
+        "description": "Toast title for settings save success"
+    },
+    "preferencesUpdated": {
+        "message": "設定が更新されました",
+        "description": "Toast description for settings save success"
+    },
+    "errorSavingSettings": {
+        "message": "設定の保存に失敗しました",
+        "description": "Toast title for settings save error"
+    },
+    "settingsReset": {
+        "message": "設定をリセットしました",
+        "description": "Toast title for settings reset success"
+    },
+    "settingsResetDescription": {
+        "message": "すべての設定がデフォルトに戻りました",
+        "description": "Toast description for settings reset success"
+    },
+    "errorResettingSettings": {
+        "message": "設定のリセットに失敗しました",
+        "description": "Toast title for settings reset error"
+    },
+    "settingsExported": {
+        "message": "設定をエクスポートしました",
+        "description": "Toast title for settings export success"
+    },
+    "settingsExportedDescription": {
+        "message": "設定ファイルがダウンロードされました",
+        "description": "Toast description for settings export success"
+    },
+    "exportFailed": {
+        "message": "エクスポートに失敗しました",
+        "description": "Toast title for settings export error"
+    },
+    "settingsImported": {
+        "message": "設定をインポートしました",
+        "description": "Toast title for settings import success"
+    },
+    "settingsImportedDescription": {
+        "message": "ファイルから設定を復元しました",
+        "description": "Toast description for settings import success"
+    },
+    "importFailed": {
+        "message": "インポートに失敗しました",
+        "description": "Toast title for settings import error"
+    },
+    "invalidSettingsFile": {
+        "message": "無効な設定ファイルです",
+        "description": "Error message for invalid settings import"
+    },
+    "export": {
+        "message": "エクスポート",
+        "description": "Export button label"
+    },
+    "import": {
+        "message": "インポート",
+        "description": "Import button label"
+    },
+    "resetAll": {
+        "message": "すべてリセット",
+        "description": "Reset all settings button label"
+    },
+    "saving": {
+        "message": "保存中...",
+        "description": "Saving state button label"
+    },
+    "saveChanges": {
+        "message": "変更を保存",
+        "description": "Save changes button label"
     }
 }

--- a/apps/extension/public/_locales/ko/messages.json
+++ b/apps/extension/public/_locales/ko/messages.json
@@ -90,5 +90,117 @@
     "enterFolderName": {
         "message": "폴더 이름 입력...",
         "description": "New folder input placeholder"
+    },
+    "noBookmarksFound": {
+        "message": "북마크를 찾을 수 없습니다",
+        "description": "Empty state when search has no results"
+    },
+    "noBookmarksYet": {
+        "message": "아직 북마크가 없습니다",
+        "description": "Empty state when there are no bookmarks"
+    },
+    "tryDifferentSearch": {
+        "message": "다른 검색어를 시도해 보세요",
+        "description": "Hint for empty search results"
+    },
+    "lightMode": {
+        "message": "라이트 모드",
+        "description": "Light mode toggle tooltip"
+    },
+    "darkMode": {
+        "message": "다크 모드",
+        "description": "Dark mode toggle tooltip"
+    },
+    "settings": {
+        "message": "설정",
+        "description": "Settings page title"
+    },
+    "settingsDescription": {
+        "message": "Bookmark Scout를 맞춤 설정하세요",
+        "description": "Settings page description"
+    },
+    "searchSettings": {
+        "message": "설정 검색...",
+        "description": "Settings search placeholder"
+    },
+    "loadingSettings": {
+        "message": "설정 로딩 중...",
+        "description": "Settings loading state"
+    },
+    "noSettingsMatch": {
+        "message": "이 카테고리에서 검색과 일치하는 설정이 없습니다",
+        "description": "Empty settings search result"
+    },
+    "settingsSaved": {
+        "message": "설정이 저장되었습니다",
+        "description": "Toast title for settings save success"
+    },
+    "preferencesUpdated": {
+        "message": "환경 설정이 업데이트되었습니다",
+        "description": "Toast description for settings save success"
+    },
+    "errorSavingSettings": {
+        "message": "설정 저장 오류",
+        "description": "Toast title for settings save error"
+    },
+    "settingsReset": {
+        "message": "설정이 초기화되었습니다",
+        "description": "Toast title for settings reset success"
+    },
+    "settingsResetDescription": {
+        "message": "모든 설정이 기본값으로 복원되었습니다",
+        "description": "Toast description for settings reset success"
+    },
+    "errorResettingSettings": {
+        "message": "설정 초기화 오류",
+        "description": "Toast title for settings reset error"
+    },
+    "settingsExported": {
+        "message": "설정이 내보내졌습니다",
+        "description": "Toast title for settings export success"
+    },
+    "settingsExportedDescription": {
+        "message": "설정 파일이 다운로드되었습니다",
+        "description": "Toast description for settings export success"
+    },
+    "exportFailed": {
+        "message": "내보내기 실패",
+        "description": "Toast title for settings export error"
+    },
+    "settingsImported": {
+        "message": "설정을 가져왔습니다",
+        "description": "Toast title for settings import success"
+    },
+    "settingsImportedDescription": {
+        "message": "파일에서 설정을 복원했습니다",
+        "description": "Toast description for settings import success"
+    },
+    "importFailed": {
+        "message": "가져오기 실패",
+        "description": "Toast title for settings import error"
+    },
+    "invalidSettingsFile": {
+        "message": "잘못된 설정 파일입니다",
+        "description": "Error message for invalid settings import"
+    },
+    "export": {
+        "message": "내보내기",
+        "description": "Export button label"
+    },
+    "import": {
+        "message": "가져오기",
+        "description": "Import button label"
+    },
+    "resetAll": {
+        "message": "전체 초기화",
+        "description": "Reset all settings button label"
+    },
+    "saving": {
+        "message": "저장 중...",
+        "description": "Saving state button label"
+    },
+    "saveChanges": {
+        "message": "변경 사항 저장",
+        "description": "Save changes button label"
     }
 }

--- a/apps/extension/src/components/bookmark/BookmarkSearch.tsx
+++ b/apps/extension/src/components/bookmark/BookmarkSearch.tsx
@@ -65,7 +65,7 @@ export function BookmarkSearch({
           size="icon"
           className="shrink-0 h-8 w-8"
           onClick={toggleTheme}
-          title={theme === 'dark' ? 'Light mode' : 'Dark mode'}
+          title={theme === 'dark' ? t('lightMode') : t('darkMode')}
         >
           {theme === 'dark' ? (
             <Sun className="h-4 w-4" />

--- a/apps/extension/src/components/page/OptionsPage.tsx
+++ b/apps/extension/src/components/page/OptionsPage.tsx
@@ -37,6 +37,7 @@ import { Slider } from '@/components/ui/slider';
 import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Toaster } from '@/components/ui/toaster';
+import { t } from '@/hooks/use-i18n';
 import { useToast } from '@/hooks/use-toast';
 import {
   type Settings,
@@ -83,13 +84,13 @@ const OptionsPage: React.FC = () => {
         setTheme(data.theme);
       }
       toast({
-        title: '✓ Settings saved',
-        description: 'Your preferences have been updated.',
+        title: `✓ ${t('settingsSaved')}`,
+        description: t('preferencesUpdated'),
         variant: 'success',
       });
     } catch (error) {
       toast({
-        title: '× Error saving settings',
+        title: `× ${t('errorSavingSettings')}`,
         description: error instanceof Error ? error.message : 'Unknown error',
         variant: 'destructive',
       });
@@ -103,13 +104,13 @@ const OptionsPage: React.FC = () => {
       await resetToDefaults();
       form.reset();
       toast({
-        title: '✓ Settings reset',
-        description: 'All settings have been restored to defaults.',
+        title: `✓ ${t('settingsReset')}`,
+        description: t('settingsResetDescription'),
         variant: 'success',
       });
     } catch (error) {
       toast({
-        title: '× Error resetting settings',
+        title: `× ${t('errorResettingSettings')}`,
         description: error instanceof Error ? error.message : 'Unknown error',
         variant: 'destructive',
       });
@@ -127,13 +128,13 @@ const OptionsPage: React.FC = () => {
       a.click();
       URL.revokeObjectURL(url);
       toast({
-        title: '✓ Settings exported',
-        description: 'Settings file has been downloaded.',
+        title: `✓ ${t('settingsExported')}`,
+        description: t('settingsExportedDescription'),
         variant: 'success',
       });
     } catch (error) {
       toast({
-        title: '× Export failed',
+        title: `× ${t('exportFailed')}`,
         description: error instanceof Error ? error.message : 'Unknown error',
         variant: 'destructive',
       });
@@ -148,14 +149,14 @@ const OptionsPage: React.FC = () => {
       const text = await file.text();
       await importSettings(text);
       toast({
-        title: '✓ Settings imported',
-        description: 'Your settings have been restored from file.',
+        title: `✓ ${t('settingsImported')}`,
+        description: t('settingsImportedDescription'),
         variant: 'success',
       });
     } catch (error) {
       toast({
-        title: '× Import failed',
-        description: error instanceof Error ? error.message : 'Invalid settings file',
+        title: `× ${t('importFailed')}`,
+        description: error instanceof Error ? error.message : t('invalidSettingsFile'),
         variant: 'destructive',
       });
     }
@@ -277,7 +278,7 @@ const OptionsPage: React.FC = () => {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-gradient-to-b from-background to-muted/20 flex items-center justify-center">
-        <div className="text-muted-foreground">Loading settings...</div>
+        <div className="text-muted-foreground">{t('loadingSettings')}</div>
       </div>
     );
   }
@@ -295,8 +296,8 @@ const OptionsPage: React.FC = () => {
               <CardHeader className="pb-4">
                 <div className="flex items-center justify-between">
                   <div>
-                    <CardTitle className="text-2xl font-bold">Settings</CardTitle>
-                    <CardDescription>Customize your Bookmark Scout experience</CardDescription>
+                    <CardTitle className="text-2xl font-bold">{t('settings')}</CardTitle>
+                    <CardDescription>{t('settingsDescription')}</CardDescription>
                   </div>
                   <div className="flex items-center gap-2">
                     <Button
@@ -318,7 +319,7 @@ const OptionsPage: React.FC = () => {
                 <div className="relative mt-4">
                   <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                   <Input
-                    placeholder="Search settings..."
+                    placeholder={t('searchSettings')}
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                     className="pl-9"
@@ -364,7 +365,7 @@ const OptionsPage: React.FC = () => {
                                 filteredFields.map((fieldKey) => renderSettingsField(fieldKey))
                               ) : (
                                 <div className="text-center py-8 text-muted-foreground">
-                                  No settings match your search in this category.
+                                  {t('noSettingsMatch')}
                                 </div>
                               )}
                             </div>
@@ -380,7 +381,7 @@ const OptionsPage: React.FC = () => {
                   <div className="flex gap-2">
                     <Button type="button" variant="outline" size="sm" onClick={handleExport}>
                       <Download className="h-4 w-4 mr-2" />
-                      Export
+                      {t('export')}
                     </Button>
                     <Button
                       type="button"
@@ -389,7 +390,7 @@ const OptionsPage: React.FC = () => {
                       onClick={() => fileInputRef.current?.click()}
                     >
                       <Upload className="h-4 w-4 mr-2" />
-                      Import
+                      {t('import')}
                     </Button>
                     <input
                       ref={fileInputRef}
@@ -407,11 +408,11 @@ const OptionsPage: React.FC = () => {
                       className="hover:bg-destructive/10 hover:text-destructive"
                     >
                       <RotateCcw className="h-4 w-4 mr-2" />
-                      Reset All
+                      {t('resetAll')}
                     </Button>
                     <Button type="submit" disabled={isSaving}>
                       <Save className="h-4 w-4 mr-2" />
-                      {isSaving ? 'Saving...' : 'Save Changes'}
+                      {isSaving ? t('saving') : t('saveChanges')}
                     </Button>
                   </div>
                 </div>

--- a/apps/extension/src/components/page/PopupPage.tsx
+++ b/apps/extension/src/components/page/PopupPage.tsx
@@ -198,11 +198,11 @@ function PopupPage() {
             <div className="flex flex-col items-center justify-center h-full p-8 text-center">
               <div className="text-4xl mb-3">🔍</div>
               <p className="text-sm text-muted-foreground">
-                {query ? 'No bookmarks found' : 'No bookmarks yet'}
+                {query ? t('noBookmarksFound') : t('noBookmarksYet')}
               </p>
               {query && (
                 <p className="text-xs text-muted-foreground mt-1">
-                  Try a different search term
+                  {t('tryDifferentSearch')}
                 </p>
               )}
             </div>

--- a/apps/extension/src/hooks/use-i18n.ts
+++ b/apps/extension/src/hooks/use-i18n.ts
@@ -5,42 +5,72 @@
 
 // Message keys available in messages.json
 export type MessageKey =
-  | 'extName'
-  | 'extDescription'
-  | 'searchPlaceholder'
-  | 'newFolder'
-  | 'retry'
-  | 'error'
-  | 'folderCreated'
-  | 'errorCreatingFolder'
-  | 'bookmarkAdded'
-  | 'errorAddingBookmark'
-  | 'bookmarkDeleted'
-  | 'errorDeletingBookmark'
-  | 'folderDeleted'
-  | 'errorDeletingFolder'
-  | 'itemMoved'
-  | 'errorMovingItem'
-  | 'addBookmark'
-  | 'addFolder'
-  | 'deleteFolder'
-  | 'deleteBookmark'
-  | 'expandAll'
-  | 'collapseAll'
-  | 'enterFolderName';
+	| "extName"
+	| "extDescription"
+	| "searchPlaceholder"
+	| "newFolder"
+	| "retry"
+	| "error"
+	| "folderCreated"
+	| "errorCreatingFolder"
+	| "bookmarkAdded"
+	| "errorAddingBookmark"
+	| "bookmarkDeleted"
+	| "errorDeletingBookmark"
+	| "folderDeleted"
+	| "errorDeletingFolder"
+	| "itemMoved"
+	| "errorMovingItem"
+	| "addBookmark"
+	| "addFolder"
+	| "deleteFolder"
+	| "deleteBookmark"
+	| "expandAll"
+	| "collapseAll"
+	| "enterFolderName"
+	// Popup page
+	| "noBookmarksFound"
+	| "noBookmarksYet"
+	| "tryDifferentSearch"
+	| "lightMode"
+	| "darkMode"
+	// Options page
+	| "settings"
+	| "settingsDescription"
+	| "searchSettings"
+	| "loadingSettings"
+	| "noSettingsMatch"
+	| "settingsSaved"
+	| "preferencesUpdated"
+	| "errorSavingSettings"
+	| "settingsReset"
+	| "settingsResetDescription"
+	| "errorResettingSettings"
+	| "settingsExported"
+	| "settingsExportedDescription"
+	| "exportFailed"
+	| "settingsImported"
+	| "settingsImportedDescription"
+	| "importFailed"
+	| "invalidSettingsFile"
+	| "export"
+	| "import"
+	| "resetAll"
+	| "saving"
+	| "saveChanges";
 
 /**
  * Get localized message from browser.i18n
  * Falls back to key if message not found
  */
 export function t(key: MessageKey, substitutions?: string | string[]): string {
-  try {
-    const message = browser.i18n.getMessage(key, substitutions);
-    return message || key;
-  } catch {
-    // Fallback for non-extension environments (like tests)
-    return key;
-  }
+	try {
+		const message = browser.i18n.getMessage(key, substitutions);
+		return message || key;
+	} catch {
+		// Fallback for non-extension environments (like tests)
+		return key;
+	}
 }
 
 /**
@@ -48,5 +78,5 @@ export function t(key: MessageKey, substitutions?: string | string[]): string {
  * Returns the t function for translations
  */
 export function useI18n() {
-  return { t };
+	return { t };
 }


### PR DESCRIPTION
## Summary

Add internationalization support for all hardcoded strings in popup and options pages.

## Changes

- **+23 message keys** in `use-i18n.ts`
- **EN/JA/KO translations** for all new keys
- **PopupPage**: empty states use `t()`
- **BookmarkSearch**: theme toggle uses `t()`
- **OptionsPage**: all strings use `t()`

Closes #147