### PR TITLE
🌐 feat(i18n): add language switcher to options page

### DIFF
--- a/apps/extension/config/settings.default.toml
+++ b/apps/extension/config/settings.default.toml
@@ -2,6 +2,9 @@
 # All configurable settings are defined here to avoid hardcoding in source code.
 
 [appearance]
+# Language preference: "auto" (follow browser), "en", "ja", or "ko"
+language = "auto"
+
 # Theme preference: "system", "light", or "dark"
 theme = "system"
 

--- a/apps/extension/src/hooks/use-i18n.ts
+++ b/apps/extension/src/hooks/use-i18n.ts
@@ -1,76 +1,125 @@
 /**
- * Simple wrapper around browser.i18n.getMessage
- * for type-safe i18n in the extension
+ * i18n hook with language override support.
+ * When language = 'auto': uses browser.i18n.getMessage
+ * When specific language: loads from bundled messages
  */
+
+// Import message files at build time for custom language support
+import messagesEn from '../../public/_locales/en/messages.json';
+import messagesJa from '../../public/_locales/ja/messages.json';
+import messagesKo from '../../public/_locales/ko/messages.json';
+
+// Bundled messages map
+const messagesMap: Record<string, Record<string, { message: string }>> = {
+  en: messagesEn,
+  ja: messagesJa,
+  ko: messagesKo,
+};
+
+// Current language setting (updated by settings storage)
+let currentLanguage: 'auto' | 'en' | 'ja' | 'ko' = 'auto';
+
+/**
+ * Set the current language. Called by settings storage on load/change.
+ */
+export function setLanguage(language: 'auto' | 'en' | 'ja' | 'ko') {
+  currentLanguage = language;
+}
+
+/**
+ * Get the current language setting.
+ */
+export function getLanguage() {
+  return currentLanguage;
+}
 
 // Message keys available in messages.json
 export type MessageKey =
-	| "extName"
-	| "extDescription"
-	| "searchPlaceholder"
-	| "newFolder"
-	| "retry"
-	| "error"
-	| "folderCreated"
-	| "errorCreatingFolder"
-	| "bookmarkAdded"
-	| "errorAddingBookmark"
-	| "bookmarkDeleted"
-	| "errorDeletingBookmark"
-	| "folderDeleted"
-	| "errorDeletingFolder"
-	| "itemMoved"
-	| "errorMovingItem"
-	| "addBookmark"
-	| "addFolder"
-	| "deleteFolder"
-	| "deleteBookmark"
-	| "expandAll"
-	| "collapseAll"
-	| "enterFolderName"
-	// Popup page
-	| "noBookmarksFound"
-	| "noBookmarksYet"
-	| "tryDifferentSearch"
-	| "lightMode"
-	| "darkMode"
-	// Options page
-	| "settings"
-	| "settingsDescription"
-	| "searchSettings"
-	| "loadingSettings"
-	| "noSettingsMatch"
-	| "settingsSaved"
-	| "preferencesUpdated"
-	| "errorSavingSettings"
-	| "settingsReset"
-	| "settingsResetDescription"
-	| "errorResettingSettings"
-	| "settingsExported"
-	| "settingsExportedDescription"
-	| "exportFailed"
-	| "settingsImported"
-	| "settingsImportedDescription"
-	| "importFailed"
-	| "invalidSettingsFile"
-	| "export"
-	| "import"
-	| "resetAll"
-	| "saving"
-	| "saveChanges";
+  | 'extName'
+  | 'extDescription'
+  | 'searchPlaceholder'
+  | 'newFolder'
+  | 'retry'
+  | 'error'
+  | 'folderCreated'
+  | 'errorCreatingFolder'
+  | 'bookmarkAdded'
+  | 'errorAddingBookmark'
+  | 'bookmarkDeleted'
+  | 'errorDeletingBookmark'
+  | 'folderDeleted'
+  | 'errorDeletingFolder'
+  | 'itemMoved'
+  | 'errorMovingItem'
+  | 'addBookmark'
+  | 'addFolder'
+  | 'deleteFolder'
+  | 'deleteBookmark'
+  | 'expandAll'
+  | 'collapseAll'
+  | 'enterFolderName'
+  // Popup page
+  | 'noBookmarksFound'
+  | 'noBookmarksYet'
+  | 'tryDifferentSearch'
+  | 'lightMode'
+  | 'darkMode'
+  // Options page
+  | 'settings'
+  | 'settingsDescription'
+  | 'searchSettings'
+  | 'loadingSettings'
+  | 'noSettingsMatch'
+  | 'settingsSaved'
+  | 'preferencesUpdated'
+  | 'errorSavingSettings'
+  | 'settingsReset'
+  | 'settingsResetDescription'
+  | 'errorResettingSettings'
+  | 'settingsExported'
+  | 'settingsExportedDescription'
+  | 'exportFailed'
+  | 'settingsImported'
+  | 'settingsImportedDescription'
+  | 'importFailed'
+  | 'invalidSettingsFile'
+  | 'export'
+  | 'import'
+  | 'resetAll'
+  | 'saving'
+  | 'saveChanges';
 
 /**
- * Get localized message from browser.i18n
- * Falls back to key if message not found
+ * Get localized message.
+ * - When language = 'auto': uses browser.i18n.getMessage (follows browser settings)
+ * - When specific language: returns from bundled messages
  */
 export function t(key: MessageKey, substitutions?: string | string[]): string {
-	try {
-		const message = browser.i18n.getMessage(key, substitutions);
-		return message || key;
-	} catch {
-		// Fallback for non-extension environments (like tests)
-		return key;
-	}
+  try {
+    // Use bundled messages when specific language is selected
+    if (currentLanguage !== 'auto') {
+      const messages = messagesMap[currentLanguage];
+      if (messages?.[key]) {
+        let message = messages[key].message;
+        // Handle substitutions ($1, $2, etc.)
+        if (substitutions) {
+          const subs = Array.isArray(substitutions) ? substitutions : [substitutions];
+          subs.forEach((sub, i) => {
+            message = message.replace(`$${i + 1}`, sub);
+          });
+        }
+        return message;
+      }
+      // Fall through to browser.i18n if key not found
+    }
+
+    // Default: use browser.i18n.getMessage (auto-detects from browser)
+    const message = browser.i18n.getMessage(key, substitutions);
+    return message || key;
+  } catch {
+    // Fallback for non-extension environments (like tests)
+    return key;
+  }
 }
 
 /**
@@ -78,5 +127,5 @@ export function t(key: MessageKey, substitutions?: string | string[]): string {
  * Returns the t function for translations
  */
 export function useI18n() {
-	return { t };
+  return { t };
 }

--- a/apps/extension/src/lib/settings-schema.ts
+++ b/apps/extension/src/lib/settings-schema.ts
@@ -14,6 +14,7 @@ import settingsToml from '../../config/settings.default.toml?raw';
  */
 interface TomlConfig {
   appearance: {
+    language: string;
     theme: string;
     show_favicons: boolean;
     favicon_size: number;
@@ -52,6 +53,12 @@ export const sortOrderSchema = z.enum(['date', 'alphabetical', 'folders']);
 export type SortOrder = z.infer<typeof sortOrderSchema>;
 
 /**
+ * Language options
+ */
+export const languageSchema = z.enum(['auto', 'en', 'ja', 'ko']);
+export type Language = z.infer<typeof languageSchema>;
+
+/**
  * Favicon size options
  */
 export const faviconSizeSchema = z.union([z.literal(16), z.literal(24), z.literal(32)]);
@@ -74,6 +81,7 @@ export type MaxSearchResults = z.infer<typeof maxSearchResultsSchema>;
  */
 export const settingsSchema = z.object({
   // Appearance - defaults from config.appearance
+  language: languageSchema.default(config.appearance.language as Language),
   theme: themeSchema.default(config.appearance.theme as Theme),
   showFavicons: z.boolean().default(config.appearance.show_favicons),
   faviconSize: faviconSizeSchema.default(config.appearance.favicon_size as FaviconSize),
@@ -110,7 +118,7 @@ export const settingsCategories = {
   appearance: {
     label: 'Appearance',
     description: 'Customize how bookmarks look',
-    fields: ['theme', 'showFavicons', 'faviconSize'] as const,
+    fields: ['language', 'theme', 'showFavicons', 'faviconSize'] as const,
   },
   search: {
     label: 'Search',
@@ -148,6 +156,17 @@ export const settingsFieldMeta: Record<
   }
 > = {
   // Appearance
+  language: {
+    label: 'Language',
+    description: 'Choose extension language',
+    type: 'select',
+    options: [
+      { value: 'auto', label: 'Auto (Browser)' },
+      { value: 'en', label: 'English' },
+      { value: 'ja', label: '日本語' },
+      { value: 'ko', label: '한국어' },
+    ],
+  },
   theme: {
     label: 'Theme',
     description: 'Choose your preferred color scheme',

--- a/apps/extension/src/lib/settings-storage.ts
+++ b/apps/extension/src/lib/settings-storage.ts
@@ -5,6 +5,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { type Settings, defaultSettings, settingsSchema } from './settings-schema';
+import { setLanguage } from '@/hooks/use-i18n';
 
 // Storage key for settings
 const SETTINGS_KEY = 'bookmark-scout-settings';
@@ -36,6 +37,8 @@ export async function getSettings(): Promise<Settings> {
       // Validate and merge with defaults
       const parsed = settingsSchema.safeParse({ ...defaultSettings, ...stored });
       if (parsed.success) {
+        // Update i18n language
+        setLanguage(parsed.data.language);
         resolve(parsed.data);
       } else {
         console.warn('Invalid settings, using defaults:', parsed.error);
@@ -130,6 +133,8 @@ export function useSettings(): {
         if (newSettings) {
           const parsed = settingsSchema.safeParse({ ...defaultSettings, ...newSettings });
           if (parsed.success) {
+            // Update i18n language
+            setLanguage(parsed.data.language);
             setSettings(parsed.data);
           }
         }


### PR DESCRIPTION
## Summary

Add language preference setting to allow users to override browser language.

## Changes

- **settings.default.toml**: Add `language = "auto"` option
- **settings-schema.ts**: Add language schema (auto/en/ja/ko) and field metadata
- **use-i18n.ts**: Refactor to support custom language loading from bundled messages
- **settings-storage.ts**: Integrate `setLanguage` on settings load/change

## How it works

- **Auto**: Uses `browser.i18n.getMessage` (follows browser settings)
- **Specific language**: Loads from bundled messages.json files

Closes #149