### PR TITLE
💄 feat(ui): make popup page responsive for sidepanel

### DIFF
--- a/apps/extension/src/entrypoints/popup/index.html
+++ b/apps/extension/src/entrypoints/popup/index.html
@@ -7,6 +7,10 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/icon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/icon-16.png" />
     <style>
+      :root {
+        --popup-width: 400px;
+        --popup-height: 600px;
+      }
       html, body {
         margin: 0;
         padding: 0;
@@ -21,10 +25,12 @@
         flex-direction: column;
         overflow: hidden;
       }
-      /* Popup dimensions */
+      /* Popup dimensions - fixed for popup, but component adapts to container */
       body {
-        width: 400px;
-        height: 600px;
+        width: var(--popup-width);
+        height: var(--popup-height);
+        min-width: 320px;
+        min-height: 400px;
       }
     </style>
   </head>

--- a/apps/extension/src/entrypoints/sidepanel/index.html
+++ b/apps/extension/src/entrypoints/sidepanel/index.html
@@ -14,12 +14,14 @@
             padding: 0;
             height: 100%;
             width: 100%;
+            min-height: 100vh;
             overflow: hidden;
         }
 
         #root {
             height: 100%;
             width: 100%;
+            min-height: 100vh;
             display: flex;
             flex-direction: column;
             overflow: hidden;

--- a/apps/extension/src/index.scss
+++ b/apps/extension/src/index.scss
@@ -121,8 +121,9 @@ body {
     overscroll-behavior: none;
     font-synthesis-weight: none;
     text-rendering: optimizeLegibility;
-    width: 400px;
-    height: 500px;
+    /* Dimensions controlled by entrypoint HTML files */
+    height: 100%;
+    width: 100%;
     overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary

Fix popup/sidepanel layouts to be responsive to container dimensions.

## Root Cause

`index.scss` had fixed body dimensions (400x500px) that overrode entrypoint HTML settings.

## Changes

| File | Change |
|------|--------|
| index.scss | Remove fixed body dimensions, use 100% |
| popup/index.html | CSS variables + min dimensions |
| sidepanel/index.html | min-height: 100vh for full height |

Closes #153