### PR TITLE
🐛 fix: drag-and-drop to move items into folders

### DIFF
--- a/apps/extension/src/styles/popup.scss
+++ b/apps/extension/src/styles/popup.scss
@@ -16,6 +16,13 @@
   transition: background-color 0.2s ease;
 }
 
+// Visual feedback when dropping INTO a folder (center zone)
+.drop-into-folder {
+  background-color: hsl(var(--primary) / 0.15);
+  border: 2px dashed hsl(var(--primary));
+  border-radius: 0.5rem;
+}
+
 // Drop indicator styles
 .drop-indicator {
   position: absolute;


### PR DESCRIPTION
## Summary

Fix drag-and-drop functionality to properly move items INTO folders.

## Root Cause

Drop zone detection always used top/bottom edges with no center detection.

## Changes

| Zone | Behavior |
|------|----------|
| Top 25% | Reorder above target (same parent) |
| Center 50% | Move INTO folder (new parent) |
| Bottom 25% | Reorder below target (same parent) |

## Visual Feedback

- Edge zones: show indicator line
- Center zone: show dashed border highlight

Closes #155