### PR TITLE
💄 fix(ui): remove hardcoded popup dimensions

### DIFF
--- a/apps/extension/src/entrypoints/popup/index.html
+++ b/apps/extension/src/entrypoints/popup/index.html
@@ -7,10 +7,6 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/icon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/icon-16.png" />
     <style>
-      :root {
-        --popup-width: 400px;
-        --popup-height: 600px;
-      }
       html, body {
         margin: 0;
         padding: 0;
@@ -24,13 +20,6 @@
         display: flex;
         flex-direction: column;
         overflow: hidden;
-      }
-      /* Popup dimensions - fixed for popup, but component adapts to container */
-      body {
-        width: var(--popup-width);
-        height: var(--popup-height);
-        min-width: 320px;
-        min-height: 400px;
       }
     </style>
   </head>


### PR DESCRIPTION
Use 100% width/height for popup instead of hardcoded values.