### PR TITLE
🐛 fix(ui): restore popup dimensions to max Chrome limits

### DIFF
--- a/apps/extension/src/entrypoints/popup/index.html
+++ b/apps/extension/src/entrypoints/popup/index.html
@@ -7,6 +7,10 @@
     <link rel="icon" type="image/png" sizes="32x32" href="/icon-32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/icon-16.png" />
     <style>
+      :root {
+        --popup-width: 800px;
+        --popup-height: 600px;
+      }
       html, body {
         margin: 0;
         padding: 0;
@@ -20,6 +24,13 @@
         display: flex;
         flex-direction: column;
         overflow: hidden;
+      }
+      /* Popup dimensions - max Chrome limits */
+      body {
+        width: var(--popup-width);
+        height: var(--popup-height);
+        min-width: 320px;
+        min-height: 400px;
       }
     </style>
   </head>


### PR DESCRIPTION
Closes #159

## Description
Restores fixed popup dimensions using Chrome's maximum limits (800×600) to fix the small popup issue caused by commit e655e6e.

## Type of Change
- [x] Bug fix

## Testing
- Verified popup displays at full 800×600 dimensions