### PR TITLE
🐛 fix(ui): resolve popup clipping and restore 400x600 dimensions

### DIFF
--- a/apps/extension/src/entrypoints/popup/index.html
+++ b/apps/extension/src/entrypoints/popup/index.html
@@ -8,15 +8,26 @@
     <link rel="icon" type="image/png" sizes="16x16" href="/icon-16.png" />
     <style>
       :root {
-        --popup-width: 800px;
+        --popup-width: 400px;
         --popup-height: 600px;
       }
-      html, body {
+      html {
+        width: var(--popup-width);
+        height: var(--popup-height);
         margin: 0;
         padding: 0;
-        height: 100%;
-        width: 100%;
         overflow: hidden;
+      }
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        min-width: 320px;
+        min-height: 400px;
       }
       #root {
         height: 100%;
@@ -24,13 +35,6 @@
         display: flex;
         flex-direction: column;
         overflow: hidden;
-      }
-      /* Popup dimensions - max Chrome limits */
-      body {
-        width: var(--popup-width);
-        height: var(--popup-height);
-        min-width: 320px;
-        min-height: 400px;
       }
     </style>
   </head>


### PR DESCRIPTION
Closes #161

## Description
Fixes the issue where the popup remained small/clipped by:
1. Moving CSS dimensions to the `html` element to force correct viewport sizing.
2. Restoring the original 400px × 600px dimensions (user feedback indicated 800px was too wide).
3. Ensuring proper overflow handling.

## Type of Change
- [x] Bug fix

## Testing
- Verified popup displays at 400x600 size correctly.