### PR TITLE
🌐 i18n: replace hardcoded strings with i18n keys

### DIFF
--- a/apps/extension/public/_locales/en/messages.json
+++ b/apps/extension/public/_locales/en/messages.json
@@ -430,5 +430,65 @@
     "settingsRecentFoldersEnabledDesc": {
         "message": "Show recent folders panel for quick bookmark saving",
         "description": "Recent folders enabled setting description"
+    },
+    "cannotGetCurrentPage": {
+        "message": "Cannot get current page",
+        "description": "Toast title when tab info unavailable"
+    },
+    "pleaseOpenWebpage": {
+        "message": "Please open a webpage first",
+        "description": "Toast description when tab info unavailable"
+    },
+    "apiKeyRequired": {
+        "message": "API Key Required",
+        "description": "Toast title when API key missing"
+    },
+    "apiKeyRequiredDesc": {
+        "message": "Please set your API key in Settings → AI",
+        "description": "Toast description when API key missing"
+    },
+    "aiRecommendationFailed": {
+        "message": "AI Recommendation Failed",
+        "description": "Toast title when AI fails"
+    },
+    "unknownError": {
+        "message": "Unknown error",
+        "description": "Generic error message"
+    },
+    "createFolderPrompt": {
+        "message": "Create folder \"$1\"",
+        "description": "Toast title for folder creation prompt"
+    },
+    "newFolderComingSoon": {
+        "message": "New folder creation coming soon!",
+        "description": "Toast description for new folder feature"
+    },
+    "aiSuggestionsFor": {
+        "message": "AI Suggestions for:",
+        "description": "AI suggestions section label"
+    },
+    "newBookmark": {
+        "message": "New Bookmark",
+        "description": "Default name for new bookmark"
+    },
+    "bookmarkAddedToFolder": {
+        "message": "\"$1\" added to \"$2\"",
+        "description": "Toast description for bookmark added"
+    },
+    "folderAddedIn": {
+        "message": "New folder \"$1\" added in \"$2\"",
+        "description": "Toast description for folder created"
+    },
+    "itemRemoved": {
+        "message": "\"$1\" has been removed",
+        "description": "Toast description for item deleted"
+    },
+    "untitled": {
+        "message": "Untitled",
+        "description": "Default name for untitled items"
+    },
+    "failedToLoadBookmarks": {
+        "message": "Failed to load bookmarks",
+        "description": "Error message for bookmark loading failure"
     }
 }

--- a/apps/extension/src/components/page/OptionsPage.tsx
+++ b/apps/extension/src/components/page/OptionsPage.tsx
@@ -138,7 +138,7 @@ const OptionsPage: React.FC = () => {
     } catch (error) {
       toast({
         title: `× ${t('errorSavingSettings')}`,
-        description: error instanceof Error ? error.message : 'Unknown error',
+        description: error instanceof Error ? error.message : t('unknownError'),
         variant: 'destructive',
       });
     } finally {
@@ -158,7 +158,7 @@ const OptionsPage: React.FC = () => {
     } catch (error) {
       toast({
         title: `× ${t('errorResettingSettings')}`,
-        description: error instanceof Error ? error.message : 'Unknown error',
+        description: error instanceof Error ? error.message : t('unknownError'),
         variant: 'destructive',
       });
     }
@@ -182,7 +182,7 @@ const OptionsPage: React.FC = () => {
     } catch (error) {
       toast({
         title: `× ${t('exportFailed')}`,
-        description: error instanceof Error ? error.message : 'Unknown error',
+        description: error instanceof Error ? error.message : t('unknownError'),
         variant: 'destructive',
       });
     }

--- a/apps/extension/src/components/page/PopupPage.tsx
+++ b/apps/extension/src/components/page/PopupPage.tsx
@@ -65,6 +65,7 @@ function PopupPage() {
   const { value: aiMaxRecommendations } = useSetting('aiMaxRecommendations');
   const { value: recentFoldersMax } = useSetting('recentFoldersMax');
   const { value: recentFoldersEnabled, isLoading: recentFoldersLoading } = useSetting('recentFoldersEnabled');
+  const { value: truncateLength } = useSetting('truncateLength');
   const [aiLoading, setAILoading] = useState(false);
   const [aiRecommendations, setAIRecommendations] = useState<FolderRecommendation[]>([]);
   const [currentTabInfo, setCurrentTabInfo] = useState<{ title: string; url: string } | null>(null);
@@ -90,8 +91,8 @@ function PopupPage() {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
       if (!tab?.title || !tab?.url) {
         toast({
-          title: 'Cannot get current page',
-          description: 'Please open a webpage first',
+          title: t('cannotGetCurrentPage'),
+          description: t('pleaseOpenWebpage'),
           variant: 'destructive',
         });
         return;
@@ -103,8 +104,8 @@ function PopupPage() {
       const { aiApiKey } = await chrome.storage.local.get('aiApiKey');
       if (!aiApiKey) {
         toast({
-          title: 'API Key Required',
-          description: 'Please set your API key in Settings → AI',
+          title: t('apiKeyRequired'),
+          description: t('apiKeyRequiredDesc'),
           variant: 'destructive',
         });
         return;
@@ -127,8 +128,8 @@ function PopupPage() {
       setAIRecommendations(recommendations);
     } catch (error) {
       toast({
-        title: 'AI Recommendation Failed',
-        description: error instanceof Error ? error.message : 'Unknown error',
+        title: t('aiRecommendationFailed'),
+        description: error instanceof Error ? error.message : t('unknownError'),
         variant: 'destructive',
       });
     } finally {
@@ -176,8 +177,8 @@ function PopupPage() {
     } else {
       // For new folder suggestions, just show a message
       toast({
-        title: `Create folder "${rec.folderPath}"`,
-        description: 'New folder creation coming soon!',
+        title: t('createFolderPrompt').replace('$1', rec.folderPath || ''),
+        description: t('newFolderComingSoon'),
       });
     }
     
@@ -314,7 +315,7 @@ function PopupPage() {
           <div className="border-b bg-muted/30 p-3 space-y-2">
             <div className="flex items-center justify-between">
               <span className="text-xs font-medium text-muted-foreground">
-                AI Suggestions for: {currentTabInfo?.title?.slice(0, 40)}...
+                {t('aiSuggestionsFor')} {currentTabInfo?.title?.slice(0, truncateLength)}...
               </span>
               <Button
                 variant="ghost"


### PR DESCRIPTION
## Description
Replace hardcoded UI strings with i18n keys for localization support.

## Changes
- Add 15 new i18n keys to `messages.json` (toast messages, error labels, AI suggestions)
- Update `PopupPage.tsx` to use `t()` for 9 strings
- Update `OptionsPage.tsx` to use `t()` for error messages
- Use `truncateLength` setting for AI suggestions title (previously hardcoded 40)

## Type of Change
- [x] 🌐 i18n

Closes #182