### PR TITLE
🌐 i18n: sync missing translations in ja/ko locales

### DIFF
--- a/apps/extension/public/_locales/ja/messages.json
+++ b/apps/extension/public/_locales/ja/messages.json
@@ -398,5 +398,97 @@
     "settingsResults": {
         "message": "$1件の結果",
         "description": "Results count option"
+    },
+    "settingsAI": {
+        "message": "AI",
+        "description": "AI category label"
+    },
+    "settingsAIDesc": {
+        "message": "AIによるフォルダ推薦",
+        "description": "AI category description"
+    },
+    "settingsRecentFoldersMax": {
+        "message": "最近のフォルダ最大数",
+        "description": "Recent folders max setting label"
+    },
+    "settingsRecentFoldersMaxDesc": {
+        "message": "クイック選択に表示する最近のフォルダの最大数",
+        "description": "Recent folders max setting description"
+    },
+    "recentFolders": {
+        "message": "最近",
+        "description": "Recent folders panel title"
+    },
+    "noRecentFolders": {
+        "message": "最近のフォルダはありません",
+        "description": "Empty state for recent folders"
+    },
+    "settingsRecentFoldersEnabled": {
+        "message": "最近のフォルダ",
+        "description": "Recent folders enabled setting label"
+    },
+    "settingsRecentFoldersEnabledDesc": {
+        "message": "クイックブックマーク保存用の最近のフォルダパネルを表示",
+        "description": "Recent folders enabled setting description"
+    },
+    "cannotGetCurrentPage": {
+        "message": "現在のページを取得できません",
+        "description": "Toast title when tab info unavailable"
+    },
+    "pleaseOpenWebpage": {
+        "message": "まずウェブページを開いてください",
+        "description": "Toast description when tab info unavailable"
+    },
+    "apiKeyRequired": {
+        "message": "APIキーが必要です",
+        "description": "Toast title when API key missing"
+    },
+    "apiKeyRequiredDesc": {
+        "message": "設定 → AIでAPIキーを設定してください",
+        "description": "Toast description when API key missing"
+    },
+    "aiRecommendationFailed": {
+        "message": "AI推薦に失敗しました",
+        "description": "Toast title when AI fails"
+    },
+    "unknownError": {
+        "message": "不明なエラー",
+        "description": "Generic error message"
+    },
+    "createFolderPrompt": {
+        "message": "フォルダ \"$1\" を作成",
+        "description": "Toast title for folder creation prompt"
+    },
+    "newFolderComingSoon": {
+        "message": "新規フォルダ作成は近日公開予定！",
+        "description": "Toast description for new folder feature"
+    },
+    "aiSuggestionsFor": {
+        "message": "AIの提案:",
+        "description": "AI suggestions section label"
+    },
+    "newBookmark": {
+        "message": "新規ブックマーク",
+        "description": "Default name for new bookmark"
+    },
+    "bookmarkAddedToFolder": {
+        "message": "\"$1\" を \"$2\" に追加しました",
+        "description": "Toast description for bookmark added"
+    },
+    "folderAddedIn": {
+        "message": "新規フォルダ \"$1\" を \"$2\" に追加しました",
+        "description": "Toast description for folder created"
+    },
+    "itemRemoved": {
+        "message": "\"$1\" を削除しました",
+        "description": "Toast description for item deleted"
+    },
+    "untitled": {
+        "message": "無題",
+        "description": "Default name for untitled items"
+    },
+    "failedToLoadBookmarks": {
+        "message": "ブックマークの読み込みに失敗しました",
+        "description": "Error message for bookmark loading failure"
     }
 }

--- a/apps/extension/public/_locales/ko/messages.json
+++ b/apps/extension/public/_locales/ko/messages.json
@@ -398,5 +398,97 @@
     "settingsResults": {
         "message": "$1개 결과",
         "description": "Results count option"
+    },
+    "settingsAI": {
+        "message": "AI",
+        "description": "AI category label"
+    },
+    "settingsAIDesc": {
+        "message": "AI 기반 폴더 추천",
+        "description": "AI category description"
+    },
+    "settingsRecentFoldersMax": {
+        "message": "최근 폴더 최대 수",
+        "description": "Recent folders max setting label"
+    },
+    "settingsRecentFoldersMaxDesc": {
+        "message": "빠른 선택에 표시할 최근 폴더의 최대 수",
+        "description": "Recent folders max setting description"
+    },
+    "recentFolders": {
+        "message": "최근",
+        "description": "Recent folders panel title"
+    },
+    "noRecentFolders": {
+        "message": "최근 폴더 없음",
+        "description": "Empty state for recent folders"
+    },
+    "settingsRecentFoldersEnabled": {
+        "message": "최근 폴더",
+        "description": "Recent folders enabled setting label"
+    },
+    "settingsRecentFoldersEnabledDesc": {
+        "message": "빠른 북마크 저장을 위한 최근 폴더 패널 표시",
+        "description": "Recent folders enabled setting description"
+    },
+    "cannotGetCurrentPage": {
+        "message": "현재 페이지를 가져올 수 없습니다",
+        "description": "Toast title when tab info unavailable"
+    },
+    "pleaseOpenWebpage": {
+        "message": "먼저 웹페이지를 열어주세요",
+        "description": "Toast description when tab info unavailable"
+    },
+    "apiKeyRequired": {
+        "message": "API 키 필요",
+        "description": "Toast title when API key missing"
+    },
+    "apiKeyRequiredDesc": {
+        "message": "설정 → AI에서 API 키를 설정해주세요",
+        "description": "Toast description when API key missing"
+    },
+    "aiRecommendationFailed": {
+        "message": "AI 추천 실패",
+        "description": "Toast title when AI fails"
+    },
+    "unknownError": {
+        "message": "알 수 없는 오류",
+        "description": "Generic error message"
+    },
+    "createFolderPrompt": {
+        "message": "폴더 \"$1\" 만들기",
+        "description": "Toast title for folder creation prompt"
+    },
+    "newFolderComingSoon": {
+        "message": "새 폴더 만들기 기능 곧 출시 예정!",
+        "description": "Toast description for new folder feature"
+    },
+    "aiSuggestionsFor": {
+        "message": "AI 추천:",
+        "description": "AI suggestions section label"
+    },
+    "newBookmark": {
+        "message": "새 북마크",
+        "description": "Default name for new bookmark"
+    },
+    "bookmarkAddedToFolder": {
+        "message": "\"$1\"을(를) \"$2\"에 추가했습니다",
+        "description": "Toast description for bookmark added"
+    },
+    "folderAddedIn": {
+        "message": "새 폴더 \"$1\"을(를) \"$2\"에 추가했습니다",
+        "description": "Toast description for folder created"
+    },
+    "itemRemoved": {
+        "message": "\"$1\"이(가) 삭제되었습니다",
+        "description": "Toast description for item deleted"
+    },
+    "untitled": {
+        "message": "제목 없음",
+        "description": "Default name for untitled items"
+    },
+    "failedToLoadBookmarks": {
+        "message": "북마크를 불러오지 못했습니다",
+        "description": "Error message for bookmark loading failure"
     }
 }


### PR DESCRIPTION
## Description
Sync the ja and ko locale files to match en, adding 23 missing i18n keys.

## Changes
- Add 23 missing keys to ja/messages.json with Japanese translations
- Add 23 missing keys to ko/messages.json with Korean translations
- Keys include: AI features, recent folders, error messages, toast notifications

## Type of Change
- [x] 🌐 i18n

Closes #184