### PR TITLE
♻️ refactor(i18n): use underscore prefixes for all 123 keys

### DIFF
--- a/apps/extension/public/_locales/en/messages.json
+++ b/apps/extension/public/_locales/en/messages.json
@@ -1,493 +1,493 @@
 {
-    "extName": {
+    "ext_name": {
         "message": "Bookmark Scout",
         "description": "Extension name"
     },
-    "extDescription": {
+    "ext_description": {
         "message": "Quickly search and save bookmarks to specific folders.",
         "description": "Extension description"
     },
-    "searchPlaceholder": {
+    "popup_searchPlaceholder": {
         "message": "Search bookmarks...",
         "description": "Search input placeholder"
     },
-    "newFolder": {
+    "popup_newFolder": {
         "message": "New Folder",
         "description": "Default name for new folder"
     },
-    "retry": {
+    "action_retry": {
         "message": "Retry",
         "description": "Retry button text"
     },
-    "error": {
+    "error_generic": {
         "message": "Error",
         "description": "Error label"
     },
-    "folderCreated": {
+    "toast_folderCreated": {
         "message": "Folder Created",
         "description": "Toast title for folder creation success"
     },
-    "errorCreatingFolder": {
+    "toast_errorCreatingFolder": {
         "message": "Error Creating Folder",
         "description": "Toast title for folder creation error"
     },
-    "bookmarkAdded": {
+    "toast_bookmarkAdded": {
         "message": "Bookmark Added",
         "description": "Toast title for bookmark addition success"
     },
-    "errorAddingBookmark": {
+    "toast_errorAddingBookmark": {
         "message": "Error Adding Bookmark",
         "description": "Toast title for bookmark addition error"
     },
-    "bookmarkDeleted": {
+    "toast_bookmarkDeleted": {
         "message": "Bookmark Deleted",
         "description": "Toast title for bookmark deletion success"
     },
-    "errorDeletingBookmark": {
+    "toast_errorDeletingBookmark": {
         "message": "Error Deleting Bookmark",
         "description": "Toast title for bookmark deletion error"
     },
-    "folderDeleted": {
+    "toast_folderDeleted": {
         "message": "Folder Deleted",
         "description": "Toast title for folder deletion success"
     },
-    "errorDeletingFolder": {
+    "toast_errorDeletingFolder": {
         "message": "Error Deleting Folder",
         "description": "Toast title for folder deletion error"
     },
-    "itemMoved": {
+    "toast_itemMoved": {
         "message": "Item Moved",
         "description": "Toast title for item move success"
     },
-    "errorMovingItem": {
+    "toast_errorMovingItem": {
         "message": "Error Moving Item",
         "description": "Toast title for item move error"
     },
-    "addBookmark": {
+    "popup_addBookmark": {
         "message": "Add current page",
         "description": "Add bookmark tooltip"
     },
-    "addFolder": {
+    "popup_addFolder": {
         "message": "Add folder",
         "description": "Add folder tooltip"
     },
-    "deleteFolder": {
+    "popup_deleteFolder": {
         "message": "Delete folder",
         "description": "Delete folder tooltip"
     },
-    "deleteBookmark": {
+    "popup_deleteBookmark": {
         "message": "Delete bookmark",
         "description": "Delete bookmark tooltip"
     },
-    "expandAll": {
+    "popup_expandAll": {
         "message": "Expand all",
         "description": "Expand all button tooltip"
     },
-    "collapseAll": {
+    "popup_collapseAll": {
         "message": "Collapse all",
         "description": "Collapse all button tooltip"
     },
-    "enterFolderName": {
+    "popup_enterFolderName": {
         "message": "Enter folder name...",
         "description": "New folder input placeholder"
     },
-    "noBookmarksFound": {
+    "state_noBookmarksFound": {
         "message": "No bookmarks found",
         "description": "Empty state when search has no results"
     },
-    "noBookmarksYet": {
+    "state_noBookmarksYet": {
         "message": "No bookmarks yet",
         "description": "Empty state when there are no bookmarks"
     },
-    "tryDifferentSearch": {
+    "state_tryDifferentSearch": {
         "message": "Try a different search term",
         "description": "Hint for empty search results"
     },
-    "lightMode": {
+    "action_lightMode": {
         "message": "Light mode",
         "description": "Light mode toggle tooltip"
     },
-    "darkMode": {
+    "action_darkMode": {
         "message": "Dark mode",
         "description": "Dark mode toggle tooltip"
     },
-    "settings": {
+    "settings_title": {
         "message": "Settings",
         "description": "Settings page title"
     },
-    "settingsDescription": {
+    "settings_description": {
         "message": "Customize your Bookmark Scout experience",
         "description": "Settings page description"
     },
-    "searchSettings": {
+    "settings_searchPlaceholder": {
         "message": "Search settings...",
         "description": "Settings search placeholder"
     },
-    "loadingSettings": {
+    "state_loadingSettings": {
         "message": "Loading settings...",
         "description": "Settings loading state"
     },
-    "noSettingsMatch": {
+    "state_noSettingsMatch": {
         "message": "No settings match your search in this category.",
         "description": "Empty settings search result"
     },
-    "settingsSaved": {
+    "toast_settingsSaved": {
         "message": "Settings saved",
         "description": "Toast title for settings save success"
     },
-    "preferencesUpdated": {
+    "toast_preferencesUpdated": {
         "message": "Your preferences have been updated.",
         "description": "Toast description for settings save success"
     },
-    "errorSavingSettings": {
+    "toast_errorSavingSettings": {
         "message": "Error saving settings",
         "description": "Toast title for settings save error"
     },
-    "settingsReset": {
+    "toast_settingsReset": {
         "message": "Settings reset",
         "description": "Toast title for settings reset success"
     },
-    "settingsResetDescription": {
+    "toast_settingsResetDescription": {
         "message": "All settings have been restored to defaults.",
         "description": "Toast description for settings reset success"
     },
-    "errorResettingSettings": {
+    "toast_errorResettingSettings": {
         "message": "Error resetting settings",
         "description": "Toast title for settings reset error"
     },
-    "settingsExported": {
+    "toast_settingsExported": {
         "message": "Settings exported",
         "description": "Toast title for settings export success"
     },
-    "settingsExportedDescription": {
+    "toast_settingsExportedDescription": {
         "message": "Settings file has been downloaded.",
         "description": "Toast description for settings export success"
     },
-    "exportFailed": {
+    "toast_exportFailed": {
         "message": "Export failed",
         "description": "Toast title for settings export error"
     },
-    "settingsImported": {
+    "toast_settingsImported": {
         "message": "Settings imported",
         "description": "Toast title for settings import success"
     },
-    "settingsImportedDescription": {
+    "toast_settingsImportedDescription": {
         "message": "Your settings have been restored from file.",
         "description": "Toast description for settings import success"
     },
-    "importFailed": {
+    "toast_importFailed": {
         "message": "Import failed",
         "description": "Toast title for settings import error"
     },
-    "invalidSettingsFile": {
+    "error_invalidSettingsFile": {
         "message": "Invalid settings file",
         "description": "Error message for invalid settings import"
     },
-    "export": {
+    "action_export": {
         "message": "Export",
         "description": "Export button label"
     },
-    "import": {
+    "action_import": {
         "message": "Import",
         "description": "Import button label"
     },
-    "resetAll": {
+    "action_resetAll": {
         "message": "Reset All",
         "description": "Reset all settings button label"
     },
-    "saving": {
+    "action_saving": {
         "message": "Saving...",
         "description": "Saving state button label"
     },
-    "saveChanges": {
+    "action_saveChanges": {
         "message": "Save Changes",
         "description": "Save changes button label"
     },
-    "settingsAppearance": {
+    "settings_appearance": {
         "message": "Appearance",
         "description": "Appearance category label"
     },
-    "settingsAppearanceDesc": {
+    "settings_appearanceDesc": {
         "message": "Customize how bookmarks look",
         "description": "Appearance category description"
     },
-    "settingsSearch": {
+    "settings_search": {
         "message": "Search",
         "description": "Search category label"
     },
-    "settingsSearchDesc": {
+    "settings_searchDesc": {
         "message": "Configure search behavior",
         "description": "Search category description"
     },
-    "settingsBehavior": {
+    "settings_behavior": {
         "message": "Behavior",
         "description": "Behavior category label"
     },
-    "settingsBehaviorDesc": {
+    "settings_behaviorDesc": {
         "message": "Control extension behavior",
         "description": "Behavior category description"
     },
-    "settingsAdvanced": {
+    "settings_advanced": {
         "message": "Advanced",
         "description": "Advanced category label"
     },
-    "settingsAdvancedDesc": {
+    "settings_advancedDesc": {
         "message": "Advanced settings",
         "description": "Advanced category description"
     },
-    "settingsLanguage": {
+    "settings_language": {
         "message": "Language",
         "description": "Language setting label"
     },
-    "settingsLanguageDesc": {
+    "settings_languageDesc": {
         "message": "Choose extension language",
         "description": "Language setting description"
     },
-    "settingsLanguageAuto": {
+    "settings_languageAuto": {
         "message": "Auto (Browser)",
         "description": "Auto language option"
     },
-    "settingsTheme": {
+    "settings_theme": {
         "message": "Theme",
         "description": "Theme setting label"
     },
-    "settingsThemeDesc": {
+    "settings_themeDesc": {
         "message": "Choose your preferred color scheme",
         "description": "Theme setting description"
     },
-    "settingsThemeSystem": {
+    "settings_themeSystem": {
         "message": "System",
         "description": "System theme option"
     },
-    "settingsThemeLight": {
+    "settings_themeLight": {
         "message": "Light",
         "description": "Light theme option"
     },
-    "settingsThemeDark": {
+    "settings_themeDark": {
         "message": "Dark",
         "description": "Dark theme option"
     },
-    "settingsShowFavicons": {
+    "settings_showFavicons": {
         "message": "Show Favicons",
         "description": "Show favicons setting label"
     },
-    "settingsShowFaviconsDesc": {
+    "settings_showFaviconsDesc": {
         "message": "Display website icons next to bookmarks",
         "description": "Show favicons setting description"
     },
-    "settingsFaviconSize": {
+    "settings_faviconSize": {
         "message": "Favicon Size",
         "description": "Favicon size setting label"
     },
-    "settingsFaviconSizeDesc": {
+    "settings_faviconSizeDesc": {
         "message": "Size of favicon icons in pixels",
         "description": "Favicon size setting description"
     },
-    "settingsFaviconSmall": {
+    "settings_faviconSmall": {
         "message": "16px (Small)",
         "description": "Small favicon size option"
     },
-    "settingsFaviconMedium": {
+    "settings_faviconMedium": {
         "message": "24px (Medium)",
         "description": "Medium favicon size option"
     },
-    "settingsFaviconLarge": {
+    "settings_faviconLarge": {
         "message": "32px (Large)",
         "description": "Large favicon size option"
     },
-    "settingsSearchDelay": {
+    "settings_searchDelay": {
         "message": "Search Delay",
         "description": "Search delay setting label"
     },
-    "settingsSearchDelayDesc": {
+    "settings_searchDelayDesc": {
         "message": "Delay before search starts after typing",
         "description": "Search delay setting description"
     },
-    "settingsMaxResults": {
+    "settings_maxResults": {
         "message": "Max Search Results",
         "description": "Max results setting label"
     },
-    "settingsMaxResultsDesc": {
+    "settings_maxResultsDesc": {
         "message": "Maximum number of results to show",
         "description": "Max results setting description"
     },
-    "settingsExpandFolders": {
+    "settings_expandFolders": {
         "message": "Expand Folders on Search",
         "description": "Expand folders setting label"
     },
-    "settingsExpandFoldersDesc": {
+    "settings_expandFoldersDesc": {
         "message": "Automatically expand folders when searching",
         "description": "Expand folders setting description"
     },
-    "settingsSearchHistory": {
+    "settings_searchHistory": {
         "message": "Search History",
         "description": "Search history setting label"
     },
-    "settingsSearchHistoryDesc": {
+    "settings_searchHistoryDesc": {
         "message": "Remember recent searches",
         "description": "Search history setting description"
     },
-    "settingsSortOrder": {
+    "settings_sortOrder": {
         "message": "Sort Order",
         "description": "Sort order setting label"
     },
-    "settingsSortOrderDesc": {
+    "settings_sortOrderDesc": {
         "message": "Default sort order for bookmarks",
         "description": "Sort order setting description"
     },
-    "settingsSortDate": {
+    "settings_sortDate": {
         "message": "Date Added",
         "description": "Date sort option"
     },
-    "settingsSortAlphabetical": {
+    "settings_sortAlphabetical": {
         "message": "Alphabetical",
         "description": "Alphabetical sort option"
     },
-    "settingsSortFolders": {
+    "settings_sortFolders": {
         "message": "Folders First",
         "description": "Folders first sort option"
     },
-    "settingsGroupByFolders": {
+    "settings_groupByFolders": {
         "message": "Group by Folders",
         "description": "Group by folders setting label"
     },
-    "settingsGroupByFoldersDesc": {
+    "settings_groupByFoldersDesc": {
         "message": "Organize bookmarks by folder structure",
         "description": "Group by folders setting description"
     },
-    "settingsConfirmDelete": {
+    "settings_confirmDelete": {
         "message": "Confirm Before Delete",
         "description": "Confirm delete setting label"
     },
-    "settingsConfirmDeleteDesc": {
+    "settings_confirmDeleteDesc": {
         "message": "Show confirmation dialog before deleting",
         "description": "Confirm delete setting description"
     },
-    "settingsDefaultFolderName": {
+    "settings_defaultFolderName": {
         "message": "Default Folder Name",
         "description": "Default folder name setting label"
     },
-    "settingsDefaultFolderNameDesc": {
+    "settings_defaultFolderNameDesc": {
         "message": "Default name for new folders",
         "description": "Default folder name setting description"
     },
-    "settingsPopupWidth": {
+    "settings_popupWidth": {
         "message": "Popup Width",
         "description": "Popup width setting label"
     },
-    "settingsPopupWidthDesc": {
+    "settings_popupWidthDesc": {
         "message": "Width of the popup window",
         "description": "Popup width setting description"
     },
-    "settingsPopupHeight": {
+    "settings_popupHeight": {
         "message": "Popup Height",
         "description": "Popup height setting label"
     },
-    "settingsPopupHeightDesc": {
+    "settings_popupHeightDesc": {
         "message": "Height of the popup window",
         "description": "Popup height setting description"
     },
-    "settingsTruncateLength": {
+    "settings_truncateLength": {
         "message": "Truncate Length",
         "description": "Truncate length setting label"
     },
-    "settingsTruncateLengthDesc": {
+    "settings_truncateLengthDesc": {
         "message": "Maximum characters before truncating text",
         "description": "Truncate length setting description"
     },
-    "settingsResults": {
+    "settings_results": {
         "message": "$1 results",
         "description": "Results count option"
     },
-    "settingsAI": {
+    "settings_ai": {
         "message": "AI",
         "description": "AI category label"
     },
-    "settingsAIDesc": {
+    "settings_aiDesc": {
         "message": "AI-powered folder recommendations",
         "description": "AI category description"
     },
-    "settingsRecentFoldersMax": {
+    "settings_recentFoldersMax": {
         "message": "Recent Folders Max",
         "description": "Recent folders max setting label"
     },
-    "settingsRecentFoldersMaxDesc": {
+    "settings_recentFoldersMaxDesc": {
         "message": "Maximum number of recent folders to show for quick select",
         "description": "Recent folders max setting description"
     },
-    "recentFolders": {
+    "popup_recentFolders": {
         "message": "Recent",
         "description": "Recent folders panel title"
     },
-    "noRecentFolders": {
+    "state_noRecentFolders": {
         "message": "No recent folders",
         "description": "Empty state for recent folders"
     },
-    "settingsRecentFoldersEnabled": {
+    "settings_recentFoldersEnabled": {
         "message": "Recent Folders",
         "description": "Recent folders enabled setting label"
     },
-    "settingsRecentFoldersEnabledDesc": {
+    "settings_recentFoldersEnabledDesc": {
         "message": "Show recent folders panel for quick bookmark saving",
         "description": "Recent folders enabled setting description"
     },
-    "cannotGetCurrentPage": {
+    "toast_cannotGetCurrentPage": {
         "message": "Cannot get current page",
         "description": "Toast title when tab info unavailable"
     },
-    "pleaseOpenWebpage": {
+    "toast_pleaseOpenWebpage": {
         "message": "Please open a webpage first",
         "description": "Toast description when tab info unavailable"
     },
-    "apiKeyRequired": {
+    "toast_apiKeyRequired": {
         "message": "API Key Required",
         "description": "Toast title when API key missing"
     },
-    "apiKeyRequiredDesc": {
+    "toast_apiKeyRequiredDesc": {
         "message": "Please set your API key in Settings → AI",
         "description": "Toast description when API key missing"
     },
-    "aiRecommendationFailed": {
+    "ai_recommendationFailed": {
         "message": "AI Recommendation Failed",
         "description": "Toast title when AI fails"
     },
-    "unknownError": {
+    "error_unknown": {
         "message": "Unknown error",
         "description": "Generic error message"
     },
-    "createFolderPrompt": {
+    "toast_createFolderPrompt": {
         "message": "Create folder \"$1\"",
         "description": "Toast title for folder creation prompt"
     },
-    "newFolderComingSoon": {
+    "toast_newFolderComingSoon": {
         "message": "New folder creation coming soon!",
         "description": "Toast description for new folder feature"
     },
-    "aiSuggestionsFor": {
+    "ai_suggestionsFor": {
         "message": "AI Suggestions for:",
         "description": "AI suggestions section label"
     },
-    "newBookmark": {
+    "popup_newBookmark": {
         "message": "New Bookmark",
         "description": "Default name for new bookmark"
     },
-    "bookmarkAddedToFolder": {
+    "toast_bookmarkAddedToFolder": {
         "message": "\"$1\" added to \"$2\"",
         "description": "Toast description for bookmark added"
     },
-    "folderAddedIn": {
+    "toast_folderAddedIn": {
         "message": "New folder \"$1\" added in \"$2\"",
         "description": "Toast description for folder created"
     },
-    "itemRemoved": {
+    "toast_itemRemoved": {
         "message": "\"$1\" has been removed",
         "description": "Toast description for item deleted"
     },
-    "untitled": {
+    "popup_untitled": {
         "message": "Untitled",
         "description": "Default name for untitled items"
     },
-    "failedToLoadBookmarks": {
+    "error_failedToLoadBookmarks": {
         "message": "Failed to load bookmarks",
         "description": "Error message for bookmark loading failure"
     }

--- a/apps/extension/public/_locales/ja/messages.json
+++ b/apps/extension/public/_locales/ja/messages.json
@@ -1,493 +1,493 @@
 {
-    "extName": {
+    "ext_name": {
         "message": "ブックマークスカウト",
         "description": "Extension name"
     },
-    "extDescription": {
+    "ext_description": {
         "message": "ブックマークを素早く検索し、特定のフォルダに保存します。",
         "description": "Extension description"
     },
-    "searchPlaceholder": {
+    "popup_searchPlaceholder": {
         "message": "ブックマークを検索...",
         "description": "Search input placeholder"
     },
-    "newFolder": {
+    "popup_newFolder": {
         "message": "新規フォルダ",
         "description": "Default name for new folder"
     },
-    "retry": {
+    "action_retry": {
         "message": "再試行",
         "description": "Retry button text"
     },
-    "error": {
+    "error_generic": {
         "message": "エラー",
         "description": "Error label"
     },
-    "folderCreated": {
+    "toast_folderCreated": {
         "message": "フォルダを作成しました",
         "description": "Toast title for folder creation success"
     },
-    "errorCreatingFolder": {
+    "toast_errorCreatingFolder": {
         "message": "フォルダの作成に失敗しました",
         "description": "Toast title for folder creation error"
     },
-    "bookmarkAdded": {
+    "toast_bookmarkAdded": {
         "message": "ブックマークを追加しました",
         "description": "Toast title for bookmark addition success"
     },
-    "errorAddingBookmark": {
+    "toast_errorAddingBookmark": {
         "message": "ブックマークの追加に失敗しました",
         "description": "Toast title for bookmark addition error"
     },
-    "bookmarkDeleted": {
+    "toast_bookmarkDeleted": {
         "message": "ブックマークを削除しました",
         "description": "Toast title for bookmark deletion success"
     },
-    "errorDeletingBookmark": {
+    "toast_errorDeletingBookmark": {
         "message": "ブックマークの削除に失敗しました",
         "description": "Toast title for bookmark deletion error"
     },
-    "folderDeleted": {
+    "toast_folderDeleted": {
         "message": "フォルダを削除しました",
         "description": "Toast title for folder deletion success"
     },
-    "errorDeletingFolder": {
+    "toast_errorDeletingFolder": {
         "message": "フォルダの削除に失敗しました",
         "description": "Toast title for folder deletion error"
     },
-    "itemMoved": {
+    "toast_itemMoved": {
         "message": "アイテムを移動しました",
         "description": "Toast title for item move success"
     },
-    "errorMovingItem": {
+    "toast_errorMovingItem": {
         "message": "アイテムの移動に失敗しました",
         "description": "Toast title for item move error"
     },
-    "addBookmark": {
+    "popup_addBookmark": {
         "message": "現在のページを追加",
         "description": "Add bookmark tooltip"
     },
-    "addFolder": {
+    "popup_addFolder": {
         "message": "フォルダを追加",
         "description": "Add folder tooltip"
     },
-    "deleteFolder": {
+    "popup_deleteFolder": {
         "message": "フォルダを削除",
         "description": "Delete folder tooltip"
     },
-    "deleteBookmark": {
+    "popup_deleteBookmark": {
         "message": "ブックマークを削除",
         "description": "Delete bookmark tooltip"
     },
-    "expandAll": {
+    "popup_expandAll": {
         "message": "すべて展開",
         "description": "Expand all button tooltip"
     },
-    "collapseAll": {
+    "popup_collapseAll": {
         "message": "すべて折りたたむ",
         "description": "Collapse all button tooltip"
     },
-    "enterFolderName": {
+    "popup_enterFolderName": {
         "message": "フォルダ名を入力...",
         "description": "New folder input placeholder"
     },
-    "noBookmarksFound": {
+    "state_noBookmarksFound": {
         "message": "ブックマークが見つかりません",
         "description": "Empty state when search has no results"
     },
-    "noBookmarksYet": {
+    "state_noBookmarksYet": {
         "message": "ブックマークはまだありません",
         "description": "Empty state when there are no bookmarks"
     },
-    "tryDifferentSearch": {
+    "state_tryDifferentSearch": {
         "message": "別の検索ワードをお試しください",
         "description": "Hint for empty search results"
     },
-    "lightMode": {
+    "action_lightMode": {
         "message": "ライトモード",
         "description": "Light mode toggle tooltip"
     },
-    "darkMode": {
+    "action_darkMode": {
         "message": "ダークモード",
         "description": "Dark mode toggle tooltip"
     },
-    "settings": {
+    "settings_title": {
         "message": "設定",
         "description": "Settings page title"
     },
-    "settingsDescription": {
+    "settings_description": {
         "message": "Bookmark Scoutをカスタマイズ",
         "description": "Settings page description"
     },
-    "searchSettings": {
+    "settings_searchPlaceholder": {
         "message": "設定を検索...",
         "description": "Settings search placeholder"
     },
-    "loadingSettings": {
+    "state_loadingSettings": {
         "message": "設定を読み込み中...",
         "description": "Settings loading state"
     },
-    "noSettingsMatch": {
+    "state_noSettingsMatch": {
         "message": "このカテゴリには一致する設定がありません",
         "description": "Empty settings search result"
     },
-    "settingsSaved": {
+    "toast_settingsSaved": {
         "message": "設定を保存しました",
         "description": "Toast title for settings save success"
     },
-    "preferencesUpdated": {
+    "toast_preferencesUpdated": {
         "message": "設定が更新されました",
         "description": "Toast description for settings save success"
     },
-    "errorSavingSettings": {
+    "toast_errorSavingSettings": {
         "message": "設定の保存に失敗しました",
         "description": "Toast title for settings save error"
     },
-    "settingsReset": {
+    "toast_settingsReset": {
         "message": "設定をリセットしました",
         "description": "Toast title for settings reset success"
     },
-    "settingsResetDescription": {
+    "toast_settingsResetDescription": {
         "message": "すべての設定がデフォルトに戻りました",
         "description": "Toast description for settings reset success"
     },
-    "errorResettingSettings": {
+    "toast_errorResettingSettings": {
         "message": "設定のリセットに失敗しました",
         "description": "Toast title for settings reset error"
     },
-    "settingsExported": {
+    "toast_settingsExported": {
         "message": "設定をエクスポートしました",
         "description": "Toast title for settings export success"
     },
-    "settingsExportedDescription": {
+    "toast_settingsExportedDescription": {
         "message": "設定ファイルがダウンロードされました",
         "description": "Toast description for settings export success"
     },
-    "exportFailed": {
+    "toast_exportFailed": {
         "message": "エクスポートに失敗しました",
         "description": "Toast title for settings export error"
     },
-    "settingsImported": {
+    "toast_settingsImported": {
         "message": "設定をインポートしました",
         "description": "Toast title for settings import success"
     },
-    "settingsImportedDescription": {
+    "toast_settingsImportedDescription": {
         "message": "ファイルから設定を復元しました",
         "description": "Toast description for settings import success"
     },
-    "importFailed": {
+    "toast_importFailed": {
         "message": "インポートに失敗しました",
         "description": "Toast title for settings import error"
     },
-    "invalidSettingsFile": {
+    "error_invalidSettingsFile": {
         "message": "無効な設定ファイルです",
         "description": "Error message for invalid settings import"
     },
-    "export": {
+    "action_export": {
         "message": "エクスポート",
         "description": "Export button label"
     },
-    "import": {
+    "action_import": {
         "message": "インポート",
         "description": "Import button label"
     },
-    "resetAll": {
+    "action_resetAll": {
         "message": "すべてリセット",
         "description": "Reset all settings button label"
     },
-    "saving": {
+    "action_saving": {
         "message": "保存中...",
         "description": "Saving state button label"
     },
-    "saveChanges": {
+    "action_saveChanges": {
         "message": "変更を保存",
         "description": "Save changes button label"
     },
-    "settingsAppearance": {
+    "settings_appearance": {
         "message": "外観",
         "description": "Appearance category label"
     },
-    "settingsAppearanceDesc": {
+    "settings_appearanceDesc": {
         "message": "ブックマークの表示をカスタマイズ",
         "description": "Appearance category description"
     },
-    "settingsSearch": {
+    "settings_search": {
         "message": "検索",
         "description": "Search category label"
     },
-    "settingsSearchDesc": {
+    "settings_searchDesc": {
         "message": "検索動作を設定",
         "description": "Search category description"
     },
-    "settingsBehavior": {
+    "settings_behavior": {
         "message": "動作",
         "description": "Behavior category label"
     },
-    "settingsBehaviorDesc": {
+    "settings_behaviorDesc": {
         "message": "拡張機能の動作を制御",
         "description": "Behavior category description"
     },
-    "settingsAdvanced": {
+    "settings_advanced": {
         "message": "詳細設定",
         "description": "Advanced category label"
     },
-    "settingsAdvancedDesc": {
+    "settings_advancedDesc": {
         "message": "詳細な設定",
         "description": "Advanced category description"
     },
-    "settingsLanguage": {
+    "settings_language": {
         "message": "言語",
         "description": "Language setting label"
     },
-    "settingsLanguageDesc": {
+    "settings_languageDesc": {
         "message": "拡張機能の言語を選択",
         "description": "Language setting description"
     },
-    "settingsLanguageAuto": {
+    "settings_languageAuto": {
         "message": "自動 (ブラウザ)",
         "description": "Auto language option"
     },
-    "settingsTheme": {
+    "settings_theme": {
         "message": "テーマ",
         "description": "Theme setting label"
     },
-    "settingsThemeDesc": {
+    "settings_themeDesc": {
         "message": "お好みの配色を選択",
         "description": "Theme setting description"
     },
-    "settingsThemeSystem": {
+    "settings_themeSystem": {
         "message": "システム",
         "description": "System theme option"
     },
-    "settingsThemeLight": {
+    "settings_themeLight": {
         "message": "ライト",
         "description": "Light theme option"
     },
-    "settingsThemeDark": {
+    "settings_themeDark": {
         "message": "ダーク",
         "description": "Dark theme option"
     },
-    "settingsShowFavicons": {
+    "settings_showFavicons": {
         "message": "ファビコンを表示",
         "description": "Show favicons setting label"
     },
-    "settingsShowFaviconsDesc": {
+    "settings_showFaviconsDesc": {
         "message": "ブックマークの横にウェブサイトアイコンを表示",
         "description": "Show favicons setting description"
     },
-    "settingsFaviconSize": {
+    "settings_faviconSize": {
         "message": "ファビコンサイズ",
         "description": "Favicon size setting label"
     },
-    "settingsFaviconSizeDesc": {
+    "settings_faviconSizeDesc": {
         "message": "ファビコンアイコンのサイズ (ピクセル)",
         "description": "Favicon size setting description"
     },
-    "settingsFaviconSmall": {
+    "settings_faviconSmall": {
         "message": "16px (小)",
         "description": "Small favicon size option"
     },
-    "settingsFaviconMedium": {
+    "settings_faviconMedium": {
         "message": "24px (中)",
         "description": "Medium favicon size option"
     },
-    "settingsFaviconLarge": {
+    "settings_faviconLarge": {
         "message": "32px (大)",
         "description": "Large favicon size option"
     },
-    "settingsSearchDelay": {
+    "settings_searchDelay": {
         "message": "検索遅延",
         "description": "Search delay setting label"
     },
-    "settingsSearchDelayDesc": {
+    "settings_searchDelayDesc": {
         "message": "入力後に検索を開始するまでの遅延",
         "description": "Search delay setting description"
     },
-    "settingsMaxResults": {
+    "settings_maxResults": {
         "message": "最大検索結果数",
         "description": "Max results setting label"
     },
-    "settingsMaxResultsDesc": {
+    "settings_maxResultsDesc": {
         "message": "表示する結果の最大数",
         "description": "Max results setting description"
     },
-    "settingsExpandFolders": {
+    "settings_expandFolders": {
         "message": "検索時にフォルダを展開",
         "description": "Expand folders setting label"
     },
-    "settingsExpandFoldersDesc": {
+    "settings_expandFoldersDesc": {
         "message": "検索時にフォルダを自動的に展開",
         "description": "Expand folders setting description"
     },
-    "settingsSearchHistory": {
+    "settings_searchHistory": {
         "message": "検索履歴",
         "description": "Search history setting label"
     },
-    "settingsSearchHistoryDesc": {
+    "settings_searchHistoryDesc": {
         "message": "最近の検索を記憶",
         "description": "Search history setting description"
     },
-    "settingsSortOrder": {
+    "settings_sortOrder": {
         "message": "並び順",
         "description": "Sort order setting label"
     },
-    "settingsSortOrderDesc": {
+    "settings_sortOrderDesc": {
         "message": "ブックマークのデフォルト並び順",
         "description": "Sort order setting description"
     },
-    "settingsSortDate": {
+    "settings_sortDate": {
         "message": "追加日順",
         "description": "Date sort option"
     },
-    "settingsSortAlphabetical": {
+    "settings_sortAlphabetical": {
         "message": "アルファベット順",
         "description": "Alphabetical sort option"
     },
-    "settingsSortFolders": {
+    "settings_sortFolders": {
         "message": "フォルダ優先",
         "description": "Folders first sort option"
     },
-    "settingsGroupByFolders": {
+    "settings_groupByFolders": {
         "message": "フォルダでグループ化",
         "description": "Group by folders setting label"
     },
-    "settingsGroupByFoldersDesc": {
+    "settings_groupByFoldersDesc": {
         "message": "フォルダ構造でブックマークを整理",
         "description": "Group by folders setting description"
     },
-    "settingsConfirmDelete": {
+    "settings_confirmDelete": {
         "message": "削除前に確認",
         "description": "Confirm delete setting label"
     },
-    "settingsConfirmDeleteDesc": {
+    "settings_confirmDeleteDesc": {
         "message": "削除前に確認ダイアログを表示",
         "description": "Confirm delete setting description"
     },
-    "settingsDefaultFolderName": {
+    "settings_defaultFolderName": {
         "message": "デフォルトフォルダ名",
         "description": "Default folder name setting label"
     },
-    "settingsDefaultFolderNameDesc": {
+    "settings_defaultFolderNameDesc": {
         "message": "新規フォルダのデフォルト名",
         "description": "Default folder name setting description"
     },
-    "settingsPopupWidth": {
+    "settings_popupWidth": {
         "message": "ポップアップ幅",
         "description": "Popup width setting label"
     },
-    "settingsPopupWidthDesc": {
+    "settings_popupWidthDesc": {
         "message": "ポップアップウィンドウの幅",
         "description": "Popup width setting description"
     },
-    "settingsPopupHeight": {
+    "settings_popupHeight": {
         "message": "ポップアップ高さ",
         "description": "Popup height setting label"
     },
-    "settingsPopupHeightDesc": {
+    "settings_popupHeightDesc": {
         "message": "ポップアップウィンドウの高さ",
         "description": "Popup height setting description"
     },
-    "settingsTruncateLength": {
+    "settings_truncateLength": {
         "message": "文字数制限",
         "description": "Truncate length setting label"
     },
-    "settingsTruncateLengthDesc": {
+    "settings_truncateLengthDesc": {
         "message": "テキストを省略する前の最大文字数",
         "description": "Truncate length setting description"
     },
-    "settingsResults": {
+    "settings_results": {
         "message": "$1件の結果",
         "description": "Results count option"
     },
-    "settingsAI": {
+    "settings_ai": {
         "message": "AI",
         "description": "AI category label"
     },
-    "settingsAIDesc": {
+    "settings_aiDesc": {
         "message": "AIによるフォルダ推薦",
         "description": "AI category description"
     },
-    "settingsRecentFoldersMax": {
+    "settings_recentFoldersMax": {
         "message": "最近のフォルダ最大数",
         "description": "Recent folders max setting label"
     },
-    "settingsRecentFoldersMaxDesc": {
+    "settings_recentFoldersMaxDesc": {
         "message": "クイック選択に表示する最近のフォルダの最大数",
         "description": "Recent folders max setting description"
     },
-    "recentFolders": {
+    "popup_recentFolders": {
         "message": "最近",
         "description": "Recent folders panel title"
     },
-    "noRecentFolders": {
+    "state_noRecentFolders": {
         "message": "最近のフォルダはありません",
         "description": "Empty state for recent folders"
     },
-    "settingsRecentFoldersEnabled": {
+    "settings_recentFoldersEnabled": {
         "message": "最近のフォルダ",
         "description": "Recent folders enabled setting label"
     },
-    "settingsRecentFoldersEnabledDesc": {
+    "settings_recentFoldersEnabledDesc": {
         "message": "クイックブックマーク保存用の最近のフォルダパネルを表示",
         "description": "Recent folders enabled setting description"
     },
-    "cannotGetCurrentPage": {
+    "toast_cannotGetCurrentPage": {
         "message": "現在のページを取得できません",
         "description": "Toast title when tab info unavailable"
     },
-    "pleaseOpenWebpage": {
+    "toast_pleaseOpenWebpage": {
         "message": "まずウェブページを開いてください",
         "description": "Toast description when tab info unavailable"
     },
-    "apiKeyRequired": {
+    "toast_apiKeyRequired": {
         "message": "APIキーが必要です",
         "description": "Toast title when API key missing"
     },
-    "apiKeyRequiredDesc": {
+    "toast_apiKeyRequiredDesc": {
         "message": "設定 → AIでAPIキーを設定してください",
         "description": "Toast description when API key missing"
     },
-    "aiRecommendationFailed": {
+    "ai_recommendationFailed": {
         "message": "AI推薦に失敗しました",
         "description": "Toast title when AI fails"
     },
-    "unknownError": {
+    "error_unknown": {
         "message": "不明なエラー",
         "description": "Generic error message"
     },
-    "createFolderPrompt": {
+    "toast_createFolderPrompt": {
         "message": "フォルダ \"$1\" を作成",
         "description": "Toast title for folder creation prompt"
     },
-    "newFolderComingSoon": {
+    "toast_newFolderComingSoon": {
         "message": "新規フォルダ作成は近日公開予定！",
         "description": "Toast description for new folder feature"
     },
-    "aiSuggestionsFor": {
+    "ai_suggestionsFor": {
         "message": "AIの提案:",
         "description": "AI suggestions section label"
     },
-    "newBookmark": {
+    "popup_newBookmark": {
         "message": "新規ブックマーク",
         "description": "Default name for new bookmark"
     },
-    "bookmarkAddedToFolder": {
+    "toast_bookmarkAddedToFolder": {
         "message": "\"$1\" を \"$2\" に追加しました",
         "description": "Toast description for bookmark added"
     },
-    "folderAddedIn": {
+    "toast_folderAddedIn": {
         "message": "新規フォルダ \"$1\" を \"$2\" に追加しました",
         "description": "Toast description for folder created"
     },
-    "itemRemoved": {
+    "toast_itemRemoved": {
         "message": "\"$1\" を削除しました",
         "description": "Toast description for item deleted"
     },
-    "untitled": {
+    "popup_untitled": {
         "message": "無題",
         "description": "Default name for untitled items"
     },
-    "failedToLoadBookmarks": {
+    "error_failedToLoadBookmarks": {
         "message": "ブックマークの読み込みに失敗しました",
         "description": "Error message for bookmark loading failure"
     }

--- a/apps/extension/public/_locales/ko/messages.json
+++ b/apps/extension/public/_locales/ko/messages.json
@@ -1,493 +1,493 @@
 {
-    "extName": {
+    "ext_name": {
         "message": "북마크 스카우트",
         "description": "Extension name"
     },
-    "extDescription": {
+    "ext_description": {
         "message": "북마크를 빠르게 검색하고 특정 폴더에 저장합니다.",
         "description": "Extension description"
     },
-    "searchPlaceholder": {
+    "popup_searchPlaceholder": {
         "message": "북마크 검색...",
         "description": "Search input placeholder"
     },
-    "newFolder": {
+    "popup_newFolder": {
         "message": "새 폴더",
         "description": "Default name for new folder"
     },
-    "retry": {
+    "action_retry": {
         "message": "다시 시도",
         "description": "Retry button text"
     },
-    "error": {
+    "error_generic": {
         "message": "오류",
         "description": "Error label"
     },
-    "folderCreated": {
+    "toast_folderCreated": {
         "message": "폴더가 생성되었습니다",
         "description": "Toast title for folder creation success"
     },
-    "errorCreatingFolder": {
+    "toast_errorCreatingFolder": {
         "message": "폴더 생성 오류",
         "description": "Toast title for folder creation error"
     },
-    "bookmarkAdded": {
+    "toast_bookmarkAdded": {
         "message": "북마크가 추가되었습니다",
         "description": "Toast title for bookmark addition success"
     },
-    "errorAddingBookmark": {
+    "toast_errorAddingBookmark": {
         "message": "북마크 추가 오류",
         "description": "Toast title for bookmark addition error"
     },
-    "bookmarkDeleted": {
+    "toast_bookmarkDeleted": {
         "message": "북마크가 삭제되었습니다",
         "description": "Toast title for bookmark deletion success"
     },
-    "errorDeletingBookmark": {
+    "toast_errorDeletingBookmark": {
         "message": "북마크 삭제 오류",
         "description": "Toast title for bookmark deletion error"
     },
-    "folderDeleted": {
+    "toast_folderDeleted": {
         "message": "폴더가 삭제되었습니다",
         "description": "Toast title for folder deletion success"
     },
-    "errorDeletingFolder": {
+    "toast_errorDeletingFolder": {
         "message": "폴더 삭제 오류",
         "description": "Toast title for folder deletion error"
     },
-    "itemMoved": {
+    "toast_itemMoved": {
         "message": "항목이 이동되었습니다",
         "description": "Toast title for item move success"
     },
-    "errorMovingItem": {
+    "toast_errorMovingItem": {
         "message": "항목 이동 오류",
         "description": "Toast title for item move error"
     },
-    "addBookmark": {
+    "popup_addBookmark": {
         "message": "현재 페이지 추가",
         "description": "Add bookmark tooltip"
     },
-    "addFolder": {
+    "popup_addFolder": {
         "message": "폴더 추가",
         "description": "Add folder tooltip"
     },
-    "deleteFolder": {
+    "popup_deleteFolder": {
         "message": "폴더 삭제",
         "description": "Delete folder tooltip"
     },
-    "deleteBookmark": {
+    "popup_deleteBookmark": {
         "message": "북마크 삭제",
         "description": "Delete bookmark tooltip"
     },
-    "expandAll": {
+    "popup_expandAll": {
         "message": "모두 펼치기",
         "description": "Expand all button tooltip"
     },
-    "collapseAll": {
+    "popup_collapseAll": {
         "message": "모두 접기",
         "description": "Collapse all button tooltip"
     },
-    "enterFolderName": {
+    "popup_enterFolderName": {
         "message": "폴더 이름 입력...",
         "description": "New folder input placeholder"
     },
-    "noBookmarksFound": {
+    "state_noBookmarksFound": {
         "message": "북마크를 찾을 수 없습니다",
         "description": "Empty state when search has no results"
     },
-    "noBookmarksYet": {
+    "state_noBookmarksYet": {
         "message": "아직 북마크가 없습니다",
         "description": "Empty state when there are no bookmarks"
     },
-    "tryDifferentSearch": {
+    "state_tryDifferentSearch": {
         "message": "다른 검색어를 시도해 보세요",
         "description": "Hint for empty search results"
     },
-    "lightMode": {
+    "action_lightMode": {
         "message": "라이트 모드",
         "description": "Light mode toggle tooltip"
     },
-    "darkMode": {
+    "action_darkMode": {
         "message": "다크 모드",
         "description": "Dark mode toggle tooltip"
     },
-    "settings": {
+    "settings_title": {
         "message": "설정",
         "description": "Settings page title"
     },
-    "settingsDescription": {
+    "settings_description": {
         "message": "Bookmark Scout를 맞춤 설정하세요",
         "description": "Settings page description"
     },
-    "searchSettings": {
+    "settings_searchPlaceholder": {
         "message": "설정 검색...",
         "description": "Settings search placeholder"
     },
-    "loadingSettings": {
+    "state_loadingSettings": {
         "message": "설정 로딩 중...",
         "description": "Settings loading state"
     },
-    "noSettingsMatch": {
+    "state_noSettingsMatch": {
         "message": "이 카테고리에서 검색과 일치하는 설정이 없습니다",
         "description": "Empty settings search result"
     },
-    "settingsSaved": {
+    "toast_settingsSaved": {
         "message": "설정이 저장되었습니다",
         "description": "Toast title for settings save success"
     },
-    "preferencesUpdated": {
+    "toast_preferencesUpdated": {
         "message": "환경 설정이 업데이트되었습니다",
         "description": "Toast description for settings save success"
     },
-    "errorSavingSettings": {
+    "toast_errorSavingSettings": {
         "message": "설정 저장 오류",
         "description": "Toast title for settings save error"
     },
-    "settingsReset": {
+    "toast_settingsReset": {
         "message": "설정이 초기화되었습니다",
         "description": "Toast title for settings reset success"
     },
-    "settingsResetDescription": {
+    "toast_settingsResetDescription": {
         "message": "모든 설정이 기본값으로 복원되었습니다",
         "description": "Toast description for settings reset success"
     },
-    "errorResettingSettings": {
+    "toast_errorResettingSettings": {
         "message": "설정 초기화 오류",
         "description": "Toast title for settings reset error"
     },
-    "settingsExported": {
+    "toast_settingsExported": {
         "message": "설정이 내보내졌습니다",
         "description": "Toast title for settings export success"
     },
-    "settingsExportedDescription": {
+    "toast_settingsExportedDescription": {
         "message": "설정 파일이 다운로드되었습니다",
         "description": "Toast description for settings export success"
     },
-    "exportFailed": {
+    "toast_exportFailed": {
         "message": "내보내기 실패",
         "description": "Toast title for settings export error"
     },
-    "settingsImported": {
+    "toast_settingsImported": {
         "message": "설정을 가져왔습니다",
         "description": "Toast title for settings import success"
     },
-    "settingsImportedDescription": {
+    "toast_settingsImportedDescription": {
         "message": "파일에서 설정을 복원했습니다",
         "description": "Toast description for settings import success"
     },
-    "importFailed": {
+    "toast_importFailed": {
         "message": "가져오기 실패",
         "description": "Toast title for settings import error"
     },
-    "invalidSettingsFile": {
+    "error_invalidSettingsFile": {
         "message": "잘못된 설정 파일입니다",
         "description": "Error message for invalid settings import"
     },
-    "export": {
+    "action_export": {
         "message": "내보내기",
         "description": "Export button label"
     },
-    "import": {
+    "action_import": {
         "message": "가져오기",
         "description": "Import button label"
     },
-    "resetAll": {
+    "action_resetAll": {
         "message": "전체 초기화",
         "description": "Reset all settings button label"
     },
-    "saving": {
+    "action_saving": {
         "message": "저장 중...",
         "description": "Saving state button label"
     },
-    "saveChanges": {
+    "action_saveChanges": {
         "message": "변경 사항 저장",
         "description": "Save changes button label"
     },
-    "settingsAppearance": {
+    "settings_appearance": {
         "message": "외관",
         "description": "Appearance category label"
     },
-    "settingsAppearanceDesc": {
+    "settings_appearanceDesc": {
         "message": "북마크 표시 방법 맞춤 설정",
         "description": "Appearance category description"
     },
-    "settingsSearch": {
+    "settings_search": {
         "message": "검색",
         "description": "Search category label"
     },
-    "settingsSearchDesc": {
+    "settings_searchDesc": {
         "message": "검색 동작 설정",
         "description": "Search category description"
     },
-    "settingsBehavior": {
+    "settings_behavior": {
         "message": "동작",
         "description": "Behavior category label"
     },
-    "settingsBehaviorDesc": {
+    "settings_behaviorDesc": {
         "message": "확장 프로그램 동작 제어",
         "description": "Behavior category description"
     },
-    "settingsAdvanced": {
+    "settings_advanced": {
         "message": "고급 설정",
         "description": "Advanced category label"
     },
-    "settingsAdvancedDesc": {
+    "settings_advancedDesc": {
         "message": "고급 설정",
         "description": "Advanced category description"
     },
-    "settingsLanguage": {
+    "settings_language": {
         "message": "언어",
         "description": "Language setting label"
     },
-    "settingsLanguageDesc": {
+    "settings_languageDesc": {
         "message": "확장 프로그램 언어 선택",
         "description": "Language setting description"
     },
-    "settingsLanguageAuto": {
+    "settings_languageAuto": {
         "message": "자동 (브라우저)",
         "description": "Auto language option"
     },
-    "settingsTheme": {
+    "settings_theme": {
         "message": "테마",
         "description": "Theme setting label"
     },
-    "settingsThemeDesc": {
+    "settings_themeDesc": {
         "message": "원하는 색상 구성표 선택",
         "description": "Theme setting description"
     },
-    "settingsThemeSystem": {
+    "settings_themeSystem": {
         "message": "시스템",
         "description": "System theme option"
     },
-    "settingsThemeLight": {
+    "settings_themeLight": {
         "message": "라이트",
         "description": "Light theme option"
     },
-    "settingsThemeDark": {
+    "settings_themeDark": {
         "message": "다크",
         "description": "Dark theme option"
     },
-    "settingsShowFavicons": {
+    "settings_showFavicons": {
         "message": "파비콘 표시",
         "description": "Show favicons setting label"
     },
-    "settingsShowFaviconsDesc": {
+    "settings_showFaviconsDesc": {
         "message": "북마크 옆에 웹사이트 아이콘 표시",
         "description": "Show favicons setting description"
     },
-    "settingsFaviconSize": {
+    "settings_faviconSize": {
         "message": "파비콘 크기",
         "description": "Favicon size setting label"
     },
-    "settingsFaviconSizeDesc": {
+    "settings_faviconSizeDesc": {
         "message": "파비콘 아이콘 크기 (픽셀)",
         "description": "Favicon size setting description"
     },
-    "settingsFaviconSmall": {
+    "settings_faviconSmall": {
         "message": "16px (작게)",
         "description": "Small favicon size option"
     },
-    "settingsFaviconMedium": {
+    "settings_faviconMedium": {
         "message": "24px (중간)",
         "description": "Medium favicon size option"
     },
-    "settingsFaviconLarge": {
+    "settings_faviconLarge": {
         "message": "32px (크게)",
         "description": "Large favicon size option"
     },
-    "settingsSearchDelay": {
+    "settings_searchDelay": {
         "message": "검색 지연",
         "description": "Search delay setting label"
     },
-    "settingsSearchDelayDesc": {
+    "settings_searchDelayDesc": {
         "message": "입력 후 검색 시작까지의 지연 시간",
         "description": "Search delay setting description"
     },
-    "settingsMaxResults": {
+    "settings_maxResults": {
         "message": "최대 검색 결과",
         "description": "Max results setting label"
     },
-    "settingsMaxResultsDesc": {
+    "settings_maxResultsDesc": {
         "message": "표시할 결과의 최대 수",
         "description": "Max results setting description"
     },
-    "settingsExpandFolders": {
+    "settings_expandFolders": {
         "message": "검색 시 폴더 펼치기",
         "description": "Expand folders setting label"
     },
-    "settingsExpandFoldersDesc": {
+    "settings_expandFoldersDesc": {
         "message": "검색 시 폴더 자동 펼치기",
         "description": "Expand folders setting description"
     },
-    "settingsSearchHistory": {
+    "settings_searchHistory": {
         "message": "검색 기록",
         "description": "Search history setting label"
     },
-    "settingsSearchHistoryDesc": {
+    "settings_searchHistoryDesc": {
         "message": "최근 검색 기억",
         "description": "Search history setting description"
     },
-    "settingsSortOrder": {
+    "settings_sortOrder": {
         "message": "정렬 순서",
         "description": "Sort order setting label"
     },
-    "settingsSortOrderDesc": {
+    "settings_sortOrderDesc": {
         "message": "북마크 기본 정렬 순서",
         "description": "Sort order setting description"
     },
-    "settingsSortDate": {
+    "settings_sortDate": {
         "message": "추가일 순",
         "description": "Date sort option"
     },
-    "settingsSortAlphabetical": {
+    "settings_sortAlphabetical": {
         "message": "알파벳 순",
         "description": "Alphabetical sort option"
     },
-    "settingsSortFolders": {
+    "settings_sortFolders": {
         "message": "폴더 우선",
         "description": "Folders first sort option"
     },
-    "settingsGroupByFolders": {
+    "settings_groupByFolders": {
         "message": "폴더별 그룹화",
         "description": "Group by folders setting label"
     },
-    "settingsGroupByFoldersDesc": {
+    "settings_groupByFoldersDesc": {
         "message": "폴더 구조로 북마크 정리",
         "description": "Group by folders setting description"
     },
-    "settingsConfirmDelete": {
+    "settings_confirmDelete": {
         "message": "삭제 전 확인",
         "description": "Confirm delete setting label"
     },
-    "settingsConfirmDeleteDesc": {
+    "settings_confirmDeleteDesc": {
         "message": "삭제 전 확인 대화상자 표시",
         "description": "Confirm delete setting description"
     },
-    "settingsDefaultFolderName": {
+    "settings_defaultFolderName": {
         "message": "기본 폴더 이름",
         "description": "Default folder name setting label"
     },
-    "settingsDefaultFolderNameDesc": {
+    "settings_defaultFolderNameDesc": {
         "message": "새 폴더의 기본 이름",
         "description": "Default folder name setting description"
     },
-    "settingsPopupWidth": {
+    "settings_popupWidth": {
         "message": "팝업 너비",
         "description": "Popup width setting label"
     },
-    "settingsPopupWidthDesc": {
+    "settings_popupWidthDesc": {
         "message": "팝업 창 너비",
         "description": "Popup width setting description"
     },
-    "settingsPopupHeight": {
+    "settings_popupHeight": {
         "message": "팝업 높이",
         "description": "Popup height setting label"
     },
-    "settingsPopupHeightDesc": {
+    "settings_popupHeightDesc": {
         "message": "팝업 창 높이",
         "description": "Popup height setting description"
     },
-    "settingsTruncateLength": {
+    "settings_truncateLength": {
         "message": "글자 수 제한",
         "description": "Truncate length setting label"
     },
-    "settingsTruncateLengthDesc": {
+    "settings_truncateLengthDesc": {
         "message": "텍스트 자르기 전 최대 글자 수",
         "description": "Truncate length setting description"
     },
-    "settingsResults": {
+    "settings_results": {
         "message": "$1개 결과",
         "description": "Results count option"
     },
-    "settingsAI": {
+    "settings_ai": {
         "message": "AI",
         "description": "AI category label"
     },
-    "settingsAIDesc": {
+    "settings_aiDesc": {
         "message": "AI 기반 폴더 추천",
         "description": "AI category description"
     },
-    "settingsRecentFoldersMax": {
+    "settings_recentFoldersMax": {
         "message": "최근 폴더 최대 수",
         "description": "Recent folders max setting label"
     },
-    "settingsRecentFoldersMaxDesc": {
+    "settings_recentFoldersMaxDesc": {
         "message": "빠른 선택에 표시할 최근 폴더의 최대 수",
         "description": "Recent folders max setting description"
     },
-    "recentFolders": {
+    "popup_recentFolders": {
         "message": "최근",
         "description": "Recent folders panel title"
     },
-    "noRecentFolders": {
+    "state_noRecentFolders": {
         "message": "최근 폴더 없음",
         "description": "Empty state for recent folders"
     },
-    "settingsRecentFoldersEnabled": {
+    "settings_recentFoldersEnabled": {
         "message": "최근 폴더",
         "description": "Recent folders enabled setting label"
     },
-    "settingsRecentFoldersEnabledDesc": {
+    "settings_recentFoldersEnabledDesc": {
         "message": "빠른 북마크 저장을 위한 최근 폴더 패널 표시",
         "description": "Recent folders enabled setting description"
     },
-    "cannotGetCurrentPage": {
+    "toast_cannotGetCurrentPage": {
         "message": "현재 페이지를 가져올 수 없습니다",
         "description": "Toast title when tab info unavailable"
     },
-    "pleaseOpenWebpage": {
+    "toast_pleaseOpenWebpage": {
         "message": "먼저 웹페이지를 열어주세요",
         "description": "Toast description when tab info unavailable"
     },
-    "apiKeyRequired": {
+    "toast_apiKeyRequired": {
         "message": "API 키 필요",
         "description": "Toast title when API key missing"
     },
-    "apiKeyRequiredDesc": {
+    "toast_apiKeyRequiredDesc": {
         "message": "설정 → AI에서 API 키를 설정해주세요",
         "description": "Toast description when API key missing"
     },
-    "aiRecommendationFailed": {
+    "ai_recommendationFailed": {
         "message": "AI 추천 실패",
         "description": "Toast title when AI fails"
     },
-    "unknownError": {
+    "error_unknown": {
         "message": "알 수 없는 오류",
         "description": "Generic error message"
     },
-    "createFolderPrompt": {
+    "toast_createFolderPrompt": {
         "message": "폴더 \"$1\" 만들기",
         "description": "Toast title for folder creation prompt"
     },
-    "newFolderComingSoon": {
+    "toast_newFolderComingSoon": {
         "message": "새 폴더 만들기 기능 곧 출시 예정!",
         "description": "Toast description for new folder feature"
     },
-    "aiSuggestionsFor": {
+    "ai_suggestionsFor": {
         "message": "AI 추천:",
         "description": "AI suggestions section label"
     },
-    "newBookmark": {
+    "popup_newBookmark": {
         "message": "새 북마크",
         "description": "Default name for new bookmark"
     },
-    "bookmarkAddedToFolder": {
+    "toast_bookmarkAddedToFolder": {
         "message": "\"$1\"을(를) \"$2\"에 추가했습니다",
         "description": "Toast description for bookmark added"
     },
-    "folderAddedIn": {
+    "toast_folderAddedIn": {
         "message": "새 폴더 \"$1\"을(를) \"$2\"에 추가했습니다",
         "description": "Toast description for folder created"
     },
-    "itemRemoved": {
+    "toast_itemRemoved": {
         "message": "\"$1\"이(가) 삭제되었습니다",
         "description": "Toast description for item deleted"
     },
-    "untitled": {
+    "popup_untitled": {
         "message": "제목 없음",
         "description": "Default name for untitled items"
     },
-    "failedToLoadBookmarks": {
+    "error_failedToLoadBookmarks": {
         "message": "북마크를 불러오지 못했습니다",
         "description": "Error message for bookmark loading failure"
     }

--- a/apps/extension/src/components/bookmark/BookmarkSearch.tsx
+++ b/apps/extension/src/components/bookmark/BookmarkSearch.tsx
@@ -46,7 +46,7 @@ export function BookmarkSearch({
         <Input
           ref={inputRef}
           type="text"
-          placeholder={t('searchPlaceholder')}
+          placeholder={t('popup_searchPlaceholder')}
           value={query}
           onChange={(e) => onQueryChange(e.target.value)}
           className="flex-1 h-8 text-sm search-input"
@@ -57,7 +57,7 @@ export function BookmarkSearch({
             size="icon"
             className="shrink-0 h-8 w-8"
             onClick={onToggleExpandAll}
-            title={forceExpandAll ? t('collapseAll') : t('expandAll')}
+            title={forceExpandAll ? t('popup_collapseAll') : t('popup_expandAll')}
           >
             {forceExpandAll ? (
               <ChevronUp className="h-4 w-4" />
@@ -71,7 +71,7 @@ export function BookmarkSearch({
           size="icon"
           className="shrink-0 h-8 w-8"
           onClick={toggleTheme}
-          title={theme === 'dark' ? t('lightMode') : t('darkMode')}
+          title={theme === 'dark' ? t('action_lightMode') : t('action_darkMode')}
         >
           {theme === 'dark' ? (
             <Sun className="h-4 w-4" />

--- a/apps/extension/src/components/bookmark/NewFolderInput.tsx
+++ b/apps/extension/src/components/bookmark/NewFolderInput.tsx
@@ -51,7 +51,7 @@ export function NewFolderInput({ value, onChange, onSubmit, onCancel }: NewFolde
           type="text"
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          placeholder={t('enterFolderName')}
+          placeholder={t('popup_enterFolderName')}
           className="h-7 text-sm w-full search-input"
           onKeyDown={(e) => {
             if (e.key === 'Escape') {

--- a/apps/extension/src/components/bookmark/RecentFoldersPanel.tsx
+++ b/apps/extension/src/components/bookmark/RecentFoldersPanel.tsx
@@ -32,7 +32,7 @@ export function RecentFoldersPanel({ onAddToFolder, maxFolders }: RecentFoldersP
       <div className="flex items-center gap-1.5 mb-1.5">
         <Clock className="h-3 w-3 text-muted-foreground" />
         <span className="text-xs font-medium text-muted-foreground">
-          {t('recentFolders')}
+          {t('popup_recentFolders')}
         </span>
       </div>
       <div className="flex flex-wrap gap-1.5">

--- a/apps/extension/src/components/page/OptionsPage.tsx
+++ b/apps/extension/src/components/page/OptionsPage.tsx
@@ -131,14 +131,14 @@ const OptionsPage: React.FC = () => {
         setTheme(data.theme);
       }
       toast({
-        title: `✓ ${t('settingsSaved')}`,
-        description: t('preferencesUpdated'),
+        title: `✓ ${t('toast_settingsSaved')}`,
+        description: t('toast_preferencesUpdated'),
         variant: 'success',
       });
     } catch (error) {
       toast({
-        title: `× ${t('errorSavingSettings')}`,
-        description: error instanceof Error ? error.message : t('unknownError'),
+        title: `× ${t('toast_errorSavingSettings')}`,
+        description: error instanceof Error ? error.message : t('error_unknown'),
         variant: 'destructive',
       });
     } finally {
@@ -151,14 +151,14 @@ const OptionsPage: React.FC = () => {
       await resetToDefaults();
       form.reset();
       toast({
-        title: `✓ ${t('settingsReset')}`,
-        description: t('settingsResetDescription'),
+        title: `✓ ${t('toast_settingsReset')}`,
+        description: t('toast_settingsResetDescription'),
         variant: 'success',
       });
     } catch (error) {
       toast({
-        title: `× ${t('errorResettingSettings')}`,
-        description: error instanceof Error ? error.message : t('unknownError'),
+        title: `× ${t('toast_errorResettingSettings')}`,
+        description: error instanceof Error ? error.message : t('error_unknown'),
         variant: 'destructive',
       });
     }
@@ -175,14 +175,14 @@ const OptionsPage: React.FC = () => {
       a.click();
       URL.revokeObjectURL(url);
       toast({
-        title: `✓ ${t('settingsExported')}`,
-        description: t('settingsExportedDescription'),
+        title: `✓ ${t('toast_settingsExported')}`,
+        description: t('toast_settingsExportedDescription'),
         variant: 'success',
       });
     } catch (error) {
       toast({
-        title: `× ${t('exportFailed')}`,
-        description: error instanceof Error ? error.message : t('unknownError'),
+        title: `× ${t('toast_exportFailed')}`,
+        description: error instanceof Error ? error.message : t('error_unknown'),
         variant: 'destructive',
       });
     }
@@ -196,14 +196,14 @@ const OptionsPage: React.FC = () => {
       const text = await file.text();
       await importSettings(text);
       toast({
-        title: `✓ ${t('settingsImported')}`,
-        description: t('settingsImportedDescription'),
+        title: `✓ ${t('toast_settingsImported')}`,
+        description: t('toast_settingsImportedDescription'),
         variant: 'success',
       });
     } catch (error) {
       toast({
-        title: `× ${t('importFailed')}`,
-        description: error instanceof Error ? error.message : t('invalidSettingsFile'),
+        title: `× ${t('toast_importFailed')}`,
+        description: error instanceof Error ? error.message : t('error_invalidSettingsFile'),
         variant: 'destructive',
       });
     }
@@ -334,7 +334,7 @@ const OptionsPage: React.FC = () => {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-gradient-to-b from-background to-muted/20 flex items-center justify-center">
-        <div className="text-muted-foreground">{t('loadingSettings')}</div>
+        <div className="text-muted-foreground">{t('state_loadingSettings')}</div>
       </div>
     );
   }
@@ -352,8 +352,8 @@ const OptionsPage: React.FC = () => {
               <CardHeader className="pb-4">
                 <div className="flex items-center justify-between">
                   <div>
-                    <CardTitle className="text-2xl font-bold">{t('settings')}</CardTitle>
-                    <CardDescription>{t('settingsDescription')}</CardDescription>
+                    <CardTitle className="text-2xl font-bold">{t('settings_title')}</CardTitle>
+                    <CardDescription>{t('settings_description')}</CardDescription>
                   </div>
                   <div className="flex items-center gap-2">
                     <Button
@@ -375,7 +375,7 @@ const OptionsPage: React.FC = () => {
                 <div className="relative mt-4">
                   <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                   <Input
-                    placeholder={t('searchSettings')}
+                    placeholder={t('settings_searchPlaceholder')}
                     value={searchQuery}
                     onChange={(e) => setSearchQuery(e.target.value)}
                     className="pl-9"
@@ -440,7 +440,7 @@ const OptionsPage: React.FC = () => {
                                 filteredFields.map((fieldKey) => renderSettingsField(fieldKey))
                               ) : (
                                 <div className="text-center py-8 text-muted-foreground">
-                                  {t('noSettingsMatch')}
+                                  {t('state_noSettingsMatch')}
                                 </div>
                               )}
                               
@@ -493,7 +493,7 @@ const OptionsPage: React.FC = () => {
                   <div className="flex gap-2">
                     <Button type="button" variant="outline" size="sm" onClick={handleExport}>
                       <Download className="h-4 w-4 mr-2" />
-                      {t('export')}
+                      {t('action_export')}
                     </Button>
                     <Button
                       type="button"
@@ -502,7 +502,7 @@ const OptionsPage: React.FC = () => {
                       onClick={() => fileInputRef.current?.click()}
                     >
                       <Upload className="h-4 w-4 mr-2" />
-                      {t('import')}
+                      {t('action_import')}
                     </Button>
                     <input
                       ref={fileInputRef}
@@ -520,11 +520,11 @@ const OptionsPage: React.FC = () => {
                       className="hover:bg-destructive/10 hover:text-destructive"
                     >
                       <RotateCcw className="h-4 w-4 mr-2" />
-                      {t('resetAll')}
+                      {t('action_resetAll')}
                     </Button>
                     <Button type="submit" disabled={isSaving}>
                       <Save className="h-4 w-4 mr-2" />
-                      {isSaving ? t('saving') : t('saveChanges')}
+                      {isSaving ? t('action_saving') : t('action_saveChanges')}
                     </Button>
                   </div>
                 </div>

--- a/apps/extension/src/components/page/PopupPage.tsx
+++ b/apps/extension/src/components/page/PopupPage.tsx
@@ -91,8 +91,8 @@ function PopupPage() {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
       if (!tab?.title || !tab?.url) {
         toast({
-          title: t('cannotGetCurrentPage'),
-          description: t('pleaseOpenWebpage'),
+          title: t('toast_cannotGetCurrentPage'),
+          description: t('toast_pleaseOpenWebpage'),
           variant: 'destructive',
         });
         return;
@@ -104,8 +104,8 @@ function PopupPage() {
       const { aiApiKey } = await chrome.storage.local.get('aiApiKey');
       if (!aiApiKey) {
         toast({
-          title: t('apiKeyRequired'),
-          description: t('apiKeyRequiredDesc'),
+          title: t('toast_apiKeyRequired'),
+          description: t('toast_apiKeyRequiredDesc'),
           variant: 'destructive',
         });
         return;
@@ -128,8 +128,8 @@ function PopupPage() {
       setAIRecommendations(recommendations);
     } catch (error) {
       toast({
-        title: t('aiRecommendationFailed'),
-        description: error instanceof Error ? error.message : t('unknownError'),
+        title: t('ai_recommendationFailed'),
+        description: error instanceof Error ? error.message : t('error_unknown'),
         variant: 'destructive',
       });
     } finally {
@@ -162,8 +162,8 @@ function PopupPage() {
     if (rec.type === 'existing' && rec.folderId) {
       const success = await withToast(
         () => addBookmarkToFolder(rec.folderId || ''),
-        t('bookmarkAdded'),
-        t('errorAddingBookmark'),
+        t('toast_bookmarkAdded'),
+        t('toast_errorAddingBookmark'),
       );
       // Track as recent folder if successful
       if (success && rec.folderId) {
@@ -177,8 +177,8 @@ function PopupPage() {
     } else {
       // For new folder suggestions, just show a message
       toast({
-        title: t('createFolderPrompt').replace('$1', rec.folderPath || ''),
-        description: t('newFolderComingSoon'),
+        title: t('toast_createFolderPrompt').replace('$1', rec.folderPath || ''),
+        description: t('toast_newFolderComingSoon'),
       });
     }
     
@@ -197,7 +197,7 @@ function PopupPage() {
               {
                 id: 'temp-folder',
                 parentId: node.id,
-                title: t('newFolder'),
+                title: t('popup_newFolder'),
                 isOpen: false,
                 isTemporary: true,
                 children: [],
@@ -232,8 +232,8 @@ function PopupPage() {
     }
     await withToast(
       () => createFolder(creatingFolderId, newFolderName),
-      t('folderCreated'),
-      t('errorCreatingFolder'),
+      t('toast_folderCreated'),
+      t('toast_errorCreatingFolder'),
     );
     setCreatingFolderId(null);
     setNewFolderName('');
@@ -253,7 +253,7 @@ function PopupPage() {
 
   const handleDropWithToast = useCallback(
     async (operation: DragOperation) => {
-      await withToast(() => handleDrop(operation), t('itemMoved'), t('errorMovingItem'));
+      await withToast(() => handleDrop(operation), t('toast_itemMoved'), t('toast_errorMovingItem'));
     },
     [handleDrop, withToast],
   );
@@ -266,9 +266,9 @@ function PopupPage() {
     return (
       <div className="p-4">
         <div className="text-red-500 mb-4">
-          {t('error')}: {error}
+          {t('error_generic')}: {error}
         </div>
-        <Button onClick={() => window.location.reload()}>{t('retry')}</Button>
+        <Button onClick={() => window.location.reload()}>{t('action_retry')}</Button>
       </div>
     );
   }
@@ -294,8 +294,8 @@ function PopupPage() {
             onAddToFolder={async (folderId) => {
             const success = await withToast(
               () => addBookmarkToFolder(folderId),
-              t('bookmarkAdded'),
-              t('errorAddingBookmark'),
+              t('toast_bookmarkAdded'),
+              t('toast_errorAddingBookmark'),
             );
             // Track as recent if successful
             if (success) {
@@ -315,7 +315,7 @@ function PopupPage() {
           <div className="border-b bg-muted/30 p-3 space-y-2">
             <div className="flex items-center justify-between">
               <span className="text-xs font-medium text-muted-foreground">
-                {t('aiSuggestionsFor')} {currentTabInfo?.title?.slice(0, truncateLength)}...
+                {t('ai_suggestionsFor')} {currentTabInfo?.title?.slice(0, truncateLength)}...
               </span>
               <Button
                 variant="ghost"
@@ -365,11 +365,11 @@ function PopupPage() {
             <div className="flex flex-col items-center justify-center h-full p-8 text-center">
               <div className="text-4xl mb-3">🔍</div>
               <p className="text-sm text-muted-foreground">
-                {query ? t('noBookmarksFound') : t('noBookmarksYet')}
+                {query ? t('state_noBookmarksFound') : t('state_noBookmarksYet')}
               </p>
               {query && (
                 <p className="text-xs text-muted-foreground mt-1">
-                  {t('tryDifferentSearch')}
+                  {t('state_tryDifferentSearch')}
                 </p>
               )}
             </div>
@@ -397,8 +397,8 @@ function PopupPage() {
                     onAddBookmark={async (id) => {
                       const success = await withToast(
                         () => addBookmarkToFolder(id),
-                        t('bookmarkAdded'),
-                        t('errorAddingBookmark'),
+                        t('toast_bookmarkAdded'),
+                        t('toast_errorAddingBookmark'),
                       );
                       if (success) {
                         try {
@@ -413,15 +413,15 @@ function PopupPage() {
                     onDeleteFolder={(id) =>
                       withToast(
                         () => removeFolder(id),
-                        t('folderDeleted'),
-                        t('errorDeletingFolder'),
+                        t('toast_folderDeleted'),
+                        t('toast_errorDeletingFolder'),
                       )
                     }
                     onDeleteBookmark={(id) =>
                       withToast(
                         () => removeBookmark(id),
-                        t('bookmarkDeleted'),
-                        t('errorDeletingBookmark'),
+                        t('toast_bookmarkDeleted'),
+                        t('toast_errorDeletingBookmark'),
                       )
                     }
                     onCreateFolder={handleCreateFolder}

--- a/apps/extension/src/lib/settings-schema.ts
+++ b/apps/extension/src/lib/settings-schema.ts
@@ -134,28 +134,28 @@ export const defaultSettings: Settings = settingsSchema.parse({});
 export function getSettingsCategories() {
   return {
     appearance: {
-      label: t('settingsAppearance'),
-      description: t('settingsAppearanceDesc'),
+      label: t('settings_appearance'),
+      description: t('settings_appearanceDesc'),
       fields: ['language', 'theme', 'showFavicons', 'faviconSize'] as const,
     },
     search: {
-      label: t('settingsSearch'),
-      description: t('settingsSearchDesc'),
+      label: t('settings_search'),
+      description: t('settings_searchDesc'),
       fields: ['searchDebounceMs', 'maxSearchResults', 'expandFoldersOnSearch', 'searchHistory'] as const,
     },
     behavior: {
-      label: t('settingsBehavior'),
-      description: t('settingsBehaviorDesc'),
+      label: t('settings_behavior'),
+      description: t('settings_behaviorDesc'),
       fields: ['sortOrder', 'groupByFolders', 'confirmBeforeDelete', 'defaultNewFolderName', 'recentFoldersEnabled', 'recentFoldersMax'] as const,
     },
     advanced: {
-      label: t('settingsAdvanced'),
-      description: t('settingsAdvancedDesc'),
+      label: t('settings_advanced'),
+      description: t('settings_advancedDesc'),
       fields: ['popupWidth', 'popupHeight', 'truncateLength'] as const,
     },
     ai: {
-      label: t('settingsAI'),
-      description: t('settingsAIDesc'),
+      label: t('settings_ai'),
+      description: t('settings_aiDesc'),
       fields: ['aiEnabled', 'aiProvider', 'aiModel'] as const,
     },
   } as const;
@@ -210,46 +210,46 @@ export function getSettingsFieldMeta(): Record<
   return {
     // Appearance
     language: {
-      label: t('settingsLanguage'),
-      description: t('settingsLanguageDesc'),
+      label: t('settings_language'),
+      description: t('settings_languageDesc'),
       type: 'select',
       options: [
-        { value: 'auto', label: t('settingsLanguageAuto') },
+        { value: 'auto', label: t('settings_languageAuto') },
         { value: 'en', label: 'English' },
         { value: 'ja', label: '日本語' },
         { value: 'ko', label: '한국어' },
       ],
     },
     theme: {
-      label: t('settingsTheme'),
-      description: t('settingsThemeDesc'),
+      label: t('settings_theme'),
+      description: t('settings_themeDesc'),
       type: 'select',
       options: [
-        { value: 'system', label: t('settingsThemeSystem') },
-        { value: 'light', label: t('settingsThemeLight') },
-        { value: 'dark', label: t('settingsThemeDark') },
+        { value: 'system', label: t('settings_themeSystem') },
+        { value: 'light', label: t('settings_themeLight') },
+        { value: 'dark', label: t('settings_themeDark') },
       ],
     },
     showFavicons: {
-      label: t('settingsShowFavicons'),
-      description: t('settingsShowFaviconsDesc'),
+      label: t('settings_showFavicons'),
+      description: t('settings_showFaviconsDesc'),
       type: 'switch',
     },
     faviconSize: {
-      label: t('settingsFaviconSize'),
-      description: t('settingsFaviconSizeDesc'),
+      label: t('settings_faviconSize'),
+      description: t('settings_faviconSizeDesc'),
       type: 'select',
       options: [
-        { value: 16, label: t('settingsFaviconSmall') },
-        { value: 24, label: t('settingsFaviconMedium') },
-        { value: 32, label: t('settingsFaviconLarge') },
+        { value: 16, label: t('settings_faviconSmall') },
+        { value: 24, label: t('settings_faviconMedium') },
+        { value: 32, label: t('settings_faviconLarge') },
       ],
     },
 
     // Search
     searchDebounceMs: {
-      label: t('settingsSearchDelay'),
-      description: t('settingsSearchDelayDesc'),
+      label: t('settings_searchDelay'),
+      description: t('settings_searchDelayDesc'),
       type: 'number',
       min: 50,
       max: 1000,
@@ -257,8 +257,8 @@ export function getSettingsFieldMeta(): Record<
       unit: 'ms',
     },
     maxSearchResults: {
-      label: t('settingsMaxResults'),
-      description: t('settingsMaxResultsDesc'),
+      label: t('settings_maxResults'),
+      description: t('settings_maxResultsDesc'),
       type: 'select',
       options: [
         { value: 10, label: t('settingsResults', '10') },
@@ -268,60 +268,60 @@ export function getSettingsFieldMeta(): Record<
       ],
     },
     expandFoldersOnSearch: {
-      label: t('settingsExpandFolders'),
-      description: t('settingsExpandFoldersDesc'),
+      label: t('settings_expandFolders'),
+      description: t('settings_expandFoldersDesc'),
       type: 'switch',
     },
     searchHistory: {
-      label: t('settingsSearchHistory'),
-      description: t('settingsSearchHistoryDesc'),
+      label: t('settings_searchHistory'),
+      description: t('settings_searchHistoryDesc'),
       type: 'switch',
     },
 
     // Behavior
     sortOrder: {
-      label: t('settingsSortOrder'),
-      description: t('settingsSortOrderDesc'),
+      label: t('settings_sortOrder'),
+      description: t('settings_sortOrderDesc'),
       type: 'select',
       options: [
-        { value: 'date', label: t('settingsSortDate') },
-        { value: 'alphabetical', label: t('settingsSortAlphabetical') },
-        { value: 'folders', label: t('settingsSortFolders') },
+        { value: 'date', label: t('settings_sortDate') },
+        { value: 'alphabetical', label: t('settings_sortAlphabetical') },
+        { value: 'folders', label: t('settings_sortFolders') },
       ],
     },
     groupByFolders: {
-      label: t('settingsGroupByFolders'),
-      description: t('settingsGroupByFoldersDesc'),
+      label: t('settings_groupByFolders'),
+      description: t('settings_groupByFoldersDesc'),
       type: 'switch',
     },
     confirmBeforeDelete: {
-      label: t('settingsConfirmDelete'),
-      description: t('settingsConfirmDeleteDesc'),
+      label: t('settings_confirmDelete'),
+      description: t('settings_confirmDeleteDesc'),
       type: 'switch',
     },
     defaultNewFolderName: {
-      label: t('settingsDefaultFolderName'),
-      description: t('settingsDefaultFolderNameDesc'),
+      label: t('settings_defaultFolderName'),
+      description: t('settings_defaultFolderNameDesc'),
       type: 'text',
     },
     recentFoldersMax: {
-      label: t('settingsRecentFoldersMax'),
-      description: t('settingsRecentFoldersMaxDesc'),
+      label: t('settings_recentFoldersMax'),
+      description: t('settings_recentFoldersMaxDesc'),
       type: 'number',
       min: 1,
       max: 10,
       step: 1,
     },
     recentFoldersEnabled: {
-      label: t('settingsRecentFoldersEnabled'),
-      description: t('settingsRecentFoldersEnabledDesc'),
+      label: t('settings_recentFoldersEnabled'),
+      description: t('settings_recentFoldersEnabledDesc'),
       type: 'switch',
     },
 
     // Advanced
     popupWidth: {
-      label: t('settingsPopupWidth'),
-      description: t('settingsPopupWidthDesc'),
+      label: t('settings_popupWidth'),
+      description: t('settings_popupWidthDesc'),
       type: 'number',
       min: 300,
       max: 800,
@@ -329,8 +329,8 @@ export function getSettingsFieldMeta(): Record<
       unit: 'px',
     },
     popupHeight: {
-      label: t('settingsPopupHeight'),
-      description: t('settingsPopupHeightDesc'),
+      label: t('settings_popupHeight'),
+      description: t('settings_popupHeightDesc'),
       type: 'number',
       min: 300,
       max: 1000,
@@ -338,8 +338,8 @@ export function getSettingsFieldMeta(): Record<
       unit: 'px',
     },
     truncateLength: {
-      label: t('settingsTruncateLength'),
-      description: t('settingsTruncateLengthDesc'),
+      label: t('settings_truncateLength'),
+      description: t('settings_truncateLengthDesc'),
       type: 'number',
       min: 20,
       max: 200,


### PR DESCRIPTION
## Description
Rename all 123 i18n keys to use consistent category prefixes with underscores.

## Changes
| Prefix | Keys | Example |
|--------|------|---------|
| `ext_` | 2 | `ext_name`, `ext_description` |
| `popup_` | 12 | `popup_searchPlaceholder` |
| `toast_` | 25 | `toast_bookmarkAdded` |
| `action_` | 8 | `action_retry` |
| `state_` | 6 | `state_noBookmarksFound` |
| `error_` | 4 | `error_unknown` |
| `ai_` | 2 | `ai_suggestionsFor` |
| `settings_` | 64 | `settings_language` |

## Type of Change
- [x] ♻️ refactor

Closes #186