### PR TITLE
🌐 fix(i18n): add extName/extDescription keys for Chrome manifest

### DIFF
--- a/apps/extension/public/_locales/en/messages.json
+++ b/apps/extension/public/_locales/en/messages.json
@@ -1,4 +1,12 @@
 {
+    "extName": {
+        "message": "Bookmark Scout",
+        "description": "Extension name (used in manifest.json)"
+    },
+    "extDescription": {
+        "message": "Quickly search and save bookmarks to specific folders.",
+        "description": "Extension description (used in manifest.json)"
+    },
     "ext_name": {
         "message": "Bookmark Scout",
         "description": "Extension name"

--- a/apps/extension/public/_locales/ja/messages.json
+++ b/apps/extension/public/_locales/ja/messages.json
@@ -1,4 +1,12 @@
 {
+    "extName": {
+        "message": "ブックマークスカウト",
+        "description": "Extension name (used in manifest.json)"
+    },
+    "extDescription": {
+        "message": "ブックマークを素早く検索し、特定のフォルダに保存します。",
+        "description": "Extension description (used in manifest.json)"
+    },
     "ext_name": {
         "message": "ブックマークスカウト",
         "description": "Extension name"

--- a/apps/extension/public/_locales/ko/messages.json
+++ b/apps/extension/public/_locales/ko/messages.json
@@ -1,4 +1,12 @@
 {
+    "extName": {
+        "message": "북마크 스카우트",
+        "description": "Extension name (used in manifest.json)"
+    },
+    "extDescription": {
+        "message": "북마크를 빠르게 검색하고 특정 폴더에 저장합니다.",
+        "description": "Extension description (used in manifest.json)"
+    },
     "ext_name": {
         "message": "북마크 스카우트",
         "description": "Extension name"


### PR DESCRIPTION
## Problem
Chrome's `__MSG_extName__` syntax requires camelCase keys (`extName`), but the recent i18n refactor renamed them to snake_case (`ext_name`). This caused the extension to fail loading with error: "Variable __MSG_extName__ used but not defined."

## Solution
Added the required camelCase keys (`extName`, `extDescription`) to all locale files while keeping the snake_case keys for backwards compatibility.

## Changes
- `apps/extension/public/_locales/en/messages.json`
- `apps/extension/public/_locales/ja/messages.json`
- `apps/extension/public/_locales/ko/messages.json`

## Testing
- [x] Extension builds successfully
- [x] Extension loads without manifest errors