### PR TITLE
🐛 fix(toast): fix auto-dismiss and make duration configurable

### DIFF
--- a/apps/extension/config/settings.default.toml
+++ b/apps/extension/config/settings.default.toml
@@ -56,6 +56,9 @@ popup_height = 500
 # Maximum characters before truncating bookmark titles (20-200)
 truncate_length = 50
 
+# Duration in milliseconds before toast notifications auto-dismiss (2000-10000)
+toast_duration_ms = 4000
+
 [ai]
 # Enable AI-powered folder recommendations
 enabled = false

--- a/apps/extension/public/_locales/en/messages.json
+++ b/apps/extension/public/_locales/en/messages.json
@@ -403,6 +403,14 @@
         "message": "Maximum characters before truncating text",
         "description": "Truncate length setting description"
     },
+    "settings_toastDuration": {
+        "message": "Toast Duration",
+        "description": "Toast duration setting label"
+    },
+    "settings_toastDurationDesc": {
+        "message": "Duration before notifications auto-dismiss",
+        "description": "Toast duration setting description"
+    },
     "settings_results": {
         "message": "$1 results",
         "description": "Results count option"

--- a/apps/extension/public/_locales/ja/messages.json
+++ b/apps/extension/public/_locales/ja/messages.json
@@ -403,6 +403,14 @@
         "message": "テキストを省略する前の最大文字数",
         "description": "Truncate length setting description"
     },
+    "settings_toastDuration": {
+        "message": "通知の表示時間",
+        "description": "Toast duration setting label"
+    },
+    "settings_toastDurationDesc": {
+        "message": "通知が自動的に消えるまでの時間",
+        "description": "Toast duration setting description"
+    },
     "settings_results": {
         "message": "$1件の結果",
         "description": "Results count option"

--- a/apps/extension/public/_locales/ko/messages.json
+++ b/apps/extension/public/_locales/ko/messages.json
@@ -403,6 +403,14 @@
         "message": "텍스트 자르기 전 최대 글자 수",
         "description": "Truncate length setting description"
     },
+    "settings_toastDuration": {
+        "message": "알림 표시 시간",
+        "description": "Toast duration setting label"
+    },
+    "settings_toastDurationDesc": {
+        "message": "알림이 자동으로 사라지기 전 시간",
+        "description": "Toast duration setting description"
+    },
     "settings_results": {
         "message": "$1개 결과",
         "description": "Results count option"

--- a/apps/extension/src/components/ui/toast.tsx
+++ b/apps/extension/src/components/ui/toast.tsx
@@ -120,8 +120,8 @@ ToastDescription.displayName = ToastPrimitives.Description.displayName;
 // Progress bar that animates from 100% to 0% over the toast duration
 const ToastProgress = React.forwardRef<
   HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement> & { variant?: 'default' | 'destructive' | 'success' | null }
->(({ className, variant, ...props }, ref) => {
+  React.HTMLAttributes<HTMLDivElement> & { variant?: 'default' | 'destructive' | 'success' | null; duration?: number }
+>(({ className, variant, duration = TOAST_DURATION, ...props }, ref) => {
   const progressColors = {
     default: 'bg-foreground/20',
     destructive: 'bg-destructive-foreground/30',
@@ -137,6 +137,7 @@ const ToastProgress = React.forwardRef<
           progressColors[variant ?? 'default'],
           className,
         )}
+        style={{ '--toast-duration': `${duration}ms` } as React.CSSProperties}
         {...props}
       />
     </div>

--- a/apps/extension/src/components/ui/toaster.tsx
+++ b/apps/extension/src/components/ui/toaster.tsx
@@ -9,14 +9,19 @@ import {
   TOAST_DURATION,
 } from '@/components/ui/toast';
 import { useToast } from '@/hooks/use-toast';
+import { useSettings } from '@/lib/settings-storage';
 
 export function Toaster() {
   const { toasts } = useToast();
+  const { settings } = useSettings();
+
+  // Use settings value if available, otherwise fall back to default
+  const toastDuration = settings?.toastDurationMs ?? TOAST_DURATION;
 
   return (
-    <ToastProvider>
+    <ToastProvider duration={toastDuration}>
       {toasts.map(({ id, title, description, action, variant, duration, ...props }) => (
-        <Toast key={id} variant={variant} duration={duration ?? TOAST_DURATION} {...props}>
+        <Toast key={id} variant={variant} duration={duration ?? toastDuration} {...props}>
           <div className="p-4 pr-8">
             <div className="grid gap-1">
               {title && <ToastTitle>{title}</ToastTitle>}
@@ -24,7 +29,7 @@ export function Toaster() {
             </div>
             {action}
           </div>
-          <ToastProgress variant={variant} />
+          <ToastProgress variant={variant} duration={duration ?? toastDuration} />
           <ToastClose />
         </Toast>
       ))}

--- a/apps/extension/src/hooks/use-toast.ts
+++ b/apps/extension/src/hooks/use-toast.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import type { ToastActionElement, ToastProps } from '@/components/ui/toast';
 
 const TOAST_LIMIT = 1;
-const TOAST_REMOVE_DELAY = 1000000;
+const TOAST_REMOVE_DELAY = 500;
 
 type ToasterToast = ToastProps & {
   id: string;

--- a/apps/extension/src/lib/settings-schema.ts
+++ b/apps/extension/src/lib/settings-schema.ts
@@ -38,6 +38,7 @@ interface TomlConfig {
     popup_width: number;
     popup_height: number;
     truncate_length: number;
+    toast_duration_ms: number;
   };
   ai: {
     enabled: boolean;
@@ -112,6 +113,7 @@ export const settingsSchema = z.object({
   popupWidth: z.number().min(300).max(800).default(config.advanced.popup_width),
   popupHeight: z.number().min(300).max(1000).default(config.advanced.popup_height),
   truncateLength: z.number().min(20).max(200).default(config.advanced.truncate_length),
+  toastDurationMs: z.number().min(2000).max(10000).default(config.advanced.toast_duration_ms),
 
   // AI - defaults from config.ai
   aiEnabled: z.boolean().default(config.ai.enabled),
@@ -151,7 +153,7 @@ export function getSettingsCategories() {
     advanced: {
       label: t('settings_advanced'),
       description: t('settings_advancedDesc'),
-      fields: ['popupWidth', 'popupHeight', 'truncateLength'] as const,
+      fields: ['popupWidth', 'popupHeight', 'truncateLength', 'toastDurationMs'] as const,
     },
     ai: {
       label: t('settings_ai'),
@@ -181,7 +183,7 @@ export const settingsCategories = {
   advanced: {
     label: 'Advanced',
     description: 'Advanced settings',
-    fields: ['popupWidth', 'popupHeight', 'truncateLength'] as const,
+    fields: ['popupWidth', 'popupHeight', 'truncateLength', 'toastDurationMs'] as const,
   },
   ai: {
     label: 'AI',
@@ -345,6 +347,15 @@ export function getSettingsFieldMeta(): Record<
       max: 200,
       step: 10,
       unit: 'chars',
+    },
+    toastDurationMs: {
+      label: t('settings_toastDuration'),
+      description: t('settings_toastDurationDesc'),
+      type: 'number',
+      min: 2000,
+      max: 10000,
+      step: 500,
+      unit: 'ms',
     },
 
     // AI
@@ -537,6 +548,15 @@ export const settingsFieldMeta: Record<
     max: 200,
     step: 10,
     unit: 'chars',
+  },
+  toastDurationMs: {
+    label: 'Toast Duration',
+    description: 'Duration before toast notifications auto-dismiss',
+    type: 'number',
+    min: 2000,
+    max: 10000,
+    step: 500,
+    unit: 'ms',
   },
 
   // AI


### PR DESCRIPTION
## Problem
- Toasts were not automatically dismissing because the `ToastProvider` lacked a `duration` prop.
- `TOAST_REMOVE_DELAY` was set to an excessively long value (16+ minutes).
- Toast duration was hardcoded and not configurable.
- Progress bar animation wasn't reflecting the effective duration.

## Solution
- Added `duration` prop to `ToastProvider` in `toaster.tsx`.
- Reduced `TOAST_REMOVE_DELAY` in `use-toast.ts` to 500ms (buffer for animation).
- Added `toastDurationMs` setting to:
  - TOML config
  - Settings schema
  - i18n files (en, ja, ko)
- Updated `Toaster` component to retrieve duration from settings.
- Updated `ToastProgress` to accept and use the computed duration for its animation style.

## Testing
- Verified build succeeds.
- Verified progress bar animation duration updates with settings.