### PR TITLE
🐛 [Fix]: Add missing auto-save i18n keys

### DIFF
--- a/apps/extension/public/_locales/en/messages.json
+++ b/apps/extension/public/_locales/en/messages.json
@@ -409,7 +409,11 @@
     },
     "settings_toastDurationDesc": {
         "message": "Duration before notifications auto-dismiss",
-        "description": "Toast duration setting description"
+        "description": "Description for toast duration setting"
+    },
+    "action_saving": {
+        "message": "Saving...",
+        "description": "Saving state indicator"
     },
     "settings_results": {
         "message": "$1 results",

--- a/apps/extension/public/_locales/ja/messages.json
+++ b/apps/extension/public/_locales/ja/messages.json
@@ -411,6 +411,10 @@
         "message": "通知が自動的に消えるまでの時間",
         "description": "Toast duration setting description"
     },
+    "action_saving": {
+        "message": "保存中...",
+        "description": "Saving state indicator"
+    },
     "settings_results": {
         "message": "$1件の結果",
         "description": "Results count option"

--- a/apps/extension/public/_locales/ko/messages.json
+++ b/apps/extension/public/_locales/ko/messages.json
@@ -409,7 +409,11 @@
     },
     "settings_toastDurationDesc": {
         "message": "알림이 자동으로 사라지기 전 시간",
-        "description": "Toast duration setting description"
+        "description": "Description for toast duration setting"
+    },
+    "action_saving": {
+        "message": "저장 중...",
+        "description": "Saving state indicator"
     },
     "settings_results": {
         "message": "$1개 결과",


### PR DESCRIPTION
## Description
Adds missing 'action_saving' translation keys to  for En, Ja, and Ko locales. These were missed in the previous PR merge.

## Fixes
- Fixes missing text in the 'Saving...' status indicator on the Options page.

## Verification
- Verified keys exist in all locale files.