### PR TITLE
✨ feat(bookmarks): refactor BookmarksPage and add Tools panel

### DIFF
--- a/apps/extension/public/_locales/en/messages.json
+++ b/apps/extension/public/_locales/en/messages.json
@@ -518,5 +518,45 @@
     "error_failedToLoadBookmarks": {
         "message": "Failed to load bookmarks",
         "description": "Error message for bookmark loading failure"
+    },
+    "tools_title": {
+        "message": "Tools",
+        "description": "Tools panel title"
+    },
+    "tools_checkDeadLinks": {
+        "message": "Check Dead Links",
+        "description": "Dead link checker tool title"
+    },
+    "tools_checkDeadLinksDesc": {
+        "message": "Scan bookmarks for broken or unreachable URLs",
+        "description": "Dead link checker description"
+    },
+    "tools_aiReorganize": {
+        "message": "AI Folder Reorganization",
+        "description": "AI reorganization tool title"
+    },
+    "tools_aiReorganizeDesc": {
+        "message": "Use AI to suggest a better folder structure",
+        "description": "AI reorganization description"
+    },
+    "tools_statistics": {
+        "message": "Bookmark Statistics",
+        "description": "Statistics tool title"
+    },
+    "tools_statisticsDesc": {
+        "message": "View stats about your bookmarks collection",
+        "description": "Statistics tool description"
+    },
+    "action_scan": {
+        "message": "Scan",
+        "description": "Scan button label"
+    },
+    "action_analyze": {
+        "message": "Analyze",
+        "description": "Analyze button label"
+    },
+    "action_view": {
+        "message": "View",
+        "description": "View button label"
     }
 }

--- a/apps/extension/public/_locales/ja/messages.json
+++ b/apps/extension/public/_locales/ja/messages.json
@@ -518,5 +518,45 @@
     "error_failedToLoadBookmarks": {
         "message": "ブックマークの読み込みに失敗しました",
         "description": "Error message for bookmark loading failure"
+    },
+    "tools_title": {
+        "message": "ツール",
+        "description": "Tools panel title"
+    },
+    "tools_checkDeadLinks": {
+        "message": "リンク切れチェック",
+        "description": "Dead link checker tool title"
+    },
+    "tools_checkDeadLinksDesc": {
+        "message": "アクセスできないURLを検出します",
+        "description": "Dead link checker description"
+    },
+    "tools_aiReorganize": {
+        "message": "AIフォルダ整理",
+        "description": "AI reorganization tool title"
+    },
+    "tools_aiReorganizeDesc": {
+        "message": "AIを使ってより良いフォルダ構造を提案します",
+        "description": "AI reorganization description"
+    },
+    "tools_statistics": {
+        "message": "ブックマーク統計",
+        "description": "Statistics tool title"
+    },
+    "tools_statisticsDesc": {
+        "message": "ブックマークの統計情報を表示します",
+        "description": "Statistics tool description"
+    },
+    "action_scan": {
+        "message": "スキャン",
+        "description": "Scan button label"
+    },
+    "action_analyze": {
+        "message": "分析",
+        "description": "Analyze button label"
+    },
+    "action_view": {
+        "message": "表示",
+        "description": "View button label"
     }
 }

--- a/apps/extension/public/_locales/ko/messages.json
+++ b/apps/extension/public/_locales/ko/messages.json
@@ -518,5 +518,45 @@
     "error_failedToLoadBookmarks": {
         "message": "북마크를 불러오지 못했습니다",
         "description": "Error message for bookmark loading failure"
+    },
+    "tools_title": {
+        "message": "도구",
+        "description": "Tools panel title"
+    },
+    "tools_checkDeadLinks": {
+        "message": "깨진 링크 확인",
+        "description": "Dead link checker tool title"
+    },
+    "tools_checkDeadLinksDesc": {
+        "message": "접근할 수 없는 URL을 검색합니다",
+        "description": "Dead link checker description"
+    },
+    "tools_aiReorganize": {
+        "message": "AI 폴더 재구성",
+        "description": "AI reorganization tool title"
+    },
+    "tools_aiReorganizeDesc": {
+        "message": "AI를 사용하여 더 나은 폴더 구조를 제안합니다",
+        "description": "AI reorganization description"
+    },
+    "tools_statistics": {
+        "message": "북마크 통계",
+        "description": "Statistics tool title"
+    },
+    "tools_statisticsDesc": {
+        "message": "북마크 컬렉션에 대한 통계를 확인합니다",
+        "description": "Statistics tool description"
+    },
+    "action_scan": {
+        "message": "검색",
+        "description": "Scan button label"
+    },
+    "action_analyze": {
+        "message": "분석",
+        "description": "Analyze button label"
+    },
+    "action_view": {
+        "message": "보기",
+        "description": "View button label"
     }
 }

--- a/apps/extension/src/components/bookmarks/ToolsPanel.tsx
+++ b/apps/extension/src/components/bookmarks/ToolsPanel.tsx
@@ -1,0 +1,132 @@
+/**
+ * ToolsPanel - Collapsible panel for power-user tools.
+ * Includes dead link checker, AI folder reorganization, and statistics.
+ */
+
+import { useState } from 'react';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import { Button } from '@/components/ui/button';
+import {
+  ChevronDown,
+  ChevronRight,
+  Link2Off,
+  Sparkles,
+  BarChart3,
+  Wrench,
+} from 'lucide-react';
+import { t } from '@/hooks/use-i18n';
+
+interface ToolCardProps {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  buttonLabel: string;
+  onClick: () => void;
+  disabled?: boolean;
+  isLoading?: boolean;
+}
+
+function ToolCard({
+  icon,
+  title,
+  description,
+  buttonLabel,
+  onClick,
+  disabled = false,
+  isLoading = false,
+}: ToolCardProps) {
+  return (
+    <div className="flex items-start gap-4 p-4 rounded-lg border bg-card">
+      <div className="flex-shrink-0 p-2 rounded-md bg-muted">{icon}</div>
+      <div className="flex-1 space-y-1">
+        <h4 className="font-medium">{title}</h4>
+        <p className="text-sm text-muted-foreground">{description}</p>
+      </div>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={onClick}
+        disabled={disabled || isLoading}
+      >
+        {isLoading ? 'Running...' : buttonLabel}
+      </Button>
+    </div>
+  );
+}
+
+export function ToolsPanel() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleCheckDeadLinks = () => {
+    // TODO: Implement dead link checker
+    console.log('Check dead links clicked');
+  };
+
+  const handleAIReorganize = () => {
+    // TODO: Implement AI folder reorganization
+    console.log('AI reorganize clicked');
+  };
+
+  const handleShowStatistics = () => {
+    // TODO: Implement bookmark statistics
+    console.log('Show statistics clicked');
+  };
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <CollapsibleTrigger asChild>
+        <Button
+          variant="ghost"
+          className="flex items-center gap-2 w-full justify-start px-4 py-2 hover:bg-muted/50"
+        >
+          <Wrench className="h-4 w-4" />
+          <span className="font-medium">{t('tools_title') || 'Tools'}</span>
+          {isOpen ? (
+            <ChevronDown className="h-4 w-4 ml-auto" />
+          ) : (
+            <ChevronRight className="h-4 w-4 ml-auto" />
+          )}
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="space-y-3 px-4 pb-4">
+        <ToolCard
+          icon={<Link2Off className="h-5 w-5 text-orange-500" />}
+          title={t('tools_checkDeadLinks') || 'Check Dead Links'}
+          description={
+            t('tools_checkDeadLinksDesc') ||
+            'Scan bookmarks for broken or unreachable URLs'
+          }
+          buttonLabel={t('action_scan') || 'Scan'}
+          onClick={handleCheckDeadLinks}
+          disabled
+        />
+        <ToolCard
+          icon={<Sparkles className="h-5 w-5 text-purple-500" />}
+          title={t('tools_aiReorganize') || 'AI Folder Reorganization'}
+          description={
+            t('tools_aiReorganizeDesc') ||
+            'Use AI to suggest a better folder structure'
+          }
+          buttonLabel={t('action_analyze') || 'Analyze'}
+          onClick={handleAIReorganize}
+          disabled
+        />
+        <ToolCard
+          icon={<BarChart3 className="h-5 w-5 text-blue-500" />}
+          title={t('tools_statistics') || 'Bookmark Statistics'}
+          description={
+            t('tools_statisticsDesc') ||
+            'View stats about your bookmarks collection'
+          }
+          buttonLabel={t('action_view') || 'View'}
+          onClick={handleShowStatistics}
+          disabled
+        />
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/apps/extension/src/components/page/BookmarksPage.tsx
+++ b/apps/extension/src/components/page/BookmarksPage.tsx
@@ -1,241 +1,29 @@
-import { Folder } from 'lucide-react';
-import { type ComponentType, useCallback, useEffect, useState } from 'react';
-import { type Bookmark, columns, ItemTypeEnum } from '../ui/table/columns';
+/**
+ * BookmarksPage - Full-page bookmark management view.
+ * Overrides chrome://bookmarks with a custom data table interface.
+ */
+
+import { t } from '@/hooks/use-i18n';
+import {
+  type Bookmark,
+  ItemTypeEnum,
+  useBookmarkNavigation,
+} from '@/hooks/use-bookmarks-page';
+import { columns } from '../ui/table/columns';
 import { DataTable } from '../ui/table/data-table';
-
-function getFaviconUrl(pageUrl: string) {
-  const url = new URL(chrome.runtime.getURL('/_favicon/'));
-  url.searchParams.set('pageUrl', pageUrl);
-  url.searchParams.set('size', '16'); // You can adjust the size as needed
-  return url.toString();
-}
-
-const Favicon: ComponentType<{ className?: string }> = ({ className }) => (
-  <img src={className} alt="favicon" className="w-4 h-4" />
-);
-
-const formatDate = (timestamp?: number) => {
-  if (!timestamp) return '';
-  const date = new Date(timestamp);
-  return date.toLocaleString();
-};
-
-const truncate = (text?: string, length = 50) => {
-  if (!text) return '';
-  return text.length > length ? `${text.slice(0, length)}...` : text;
-};
-
-const processNode = (node: chrome.bookmarks.BookmarkTreeNode, parentId = 'Root'): Bookmark => {
-  // A node is a folder if it has children, regardless of whether it has a URL
-  const isFolder = node.children !== undefined;
-
-  return {
-    type: isFolder ? ItemTypeEnum.Folder : ItemTypeEnum.Link,
-    id: node.id,
-    parentId: parentId,
-    index: node.index,
-    title: truncate(node.title, 30),
-    url: truncate(node.url, 50),
-    dateAdded: formatDate(node.dateAdded),
-    dateGroupModified: formatDate(node.dateGroupModified),
-    unmodifiable: node.unmodifiable as 'managed',
-  };
-};
-
-async function getTopLevelFolders(): Promise<Bookmark[]> {
-  return new Promise((resolve) => {
-    if (chrome?.bookmarks) {
-      chrome.bookmarks.getTree((nodes) => {
-        // Filter out the root node and only process the actual top-level folders
-        const topLevelFolders = nodes[0].children?.map((node) => processNode(node)) || [];
-        resolve(topLevelFolders);
-      });
-    } else {
-      resolve([]);
-    }
-  });
-}
-
-async function getFolderContents(folderId: string): Promise<Bookmark[]> {
-  return new Promise((resolve) => {
-    if (chrome?.bookmarks) {
-      chrome.bookmarks.getTree((nodes) => {
-        // Find the target folder in the tree
-        const findFolder = (
-          nodes: chrome.bookmarks.BookmarkTreeNode[],
-        ): chrome.bookmarks.BookmarkTreeNode | null => {
-          for (const node of nodes) {
-            if (node.id === folderId) {
-              return node;
-            }
-            if (node.children) {
-              const found = findFolder(node.children);
-              if (found) return found;
-            }
-          }
-          return null;
-        };
-
-        const targetFolder = findFolder(nodes);
-        if (targetFolder?.children) {
-          const contents = targetFolder.children.map((node) => processNode(node, folderId));
-          resolve(contents);
-        } else {
-          resolve([]);
-        }
-      });
-    } else {
-      resolve([]);
-    }
-  });
-}
-
-export const parentIdMap: Record<
-  string,
-  { value: string; label: string; icon: ComponentType<{ className?: string }> }
-> = {};
-
-export const useParentIdMap = () => {
-  const [parentIdMapState, setParentIdMap] = useState(parentIdMap);
-
-  useEffect(() => {
-    if (chrome?.bookmarks) {
-      chrome.bookmarks.getTree((nodes) => {
-        const map: Record<
-          string,
-          { value: string; label: string; icon: ComponentType<{ className?: string }> }
-        > = {};
-
-        const processNode = (node: chrome.bookmarks.BookmarkTreeNode, _parentId = 'Root') => {
-          map[node.id] = {
-            value: node.id,
-            label: node.title || 'Untitled',
-            icon: Folder, // Generate favicon
-          };
-
-          if (node.children) {
-            node.children.forEach((child) => {
-              processNode(child, node.id);
-            });
-          }
-        };
-
-        nodes.forEach((node) => {
-          processNode(node);
-        });
-        setParentIdMap(map);
-      });
-    }
-  }, []);
-
-  return parentIdMapState;
-};
-
-export const urlMap: Record<
-  string,
-  { value: string; label: string; icon: ComponentType<{ className?: string }> }
-> = {};
-
-export const useUrlMap = () => {
-  const [urlMapState, setUrlMap] = useState(urlMap);
-
-  useEffect(() => {
-    if (chrome?.bookmarks) {
-      chrome.bookmarks.getTree((nodes) => {
-        const map: Record<
-          string,
-          { value: string; label: string; icon: ComponentType<{ className?: string }> }
-        > = {};
-
-        const processNode = (node: chrome.bookmarks.BookmarkTreeNode) => {
-          if (node.children) {
-            node.children.forEach((child) => {
-              processNode(child);
-            });
-          } else if (node.url) {
-            const domain = new URL(node.url).hostname.split('.').slice(-2).join('.');
-            map[domain] = {
-              value: domain,
-              label: domain,
-              icon: () => <Favicon className={getFaviconUrl(node.url || '')} />, // Generate favicon
-            };
-          }
-        };
-
-        nodes.forEach((node) => {
-          processNode(node);
-        });
-        setUrlMap(map);
-      });
-    }
-  }, []);
-
-  return urlMapState;
-};
+import { ToolsPanel } from '../bookmarks/ToolsPanel';
 
 export default function BookmarksPage() {
-  const [currentFolder, setCurrentFolder] = useState<string | null>(null);
-  const [data, setData] = useState<Bookmark[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  // Handle initial URL parameter
-  useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const folderId = urlParams.get('id');
-    if (folderId) {
-      setCurrentFolder(folderId);
-    }
-  }, []);
-
-  const refreshCurrentFolder = useCallback(async () => {
-    setIsLoading(true);
-    setError(null);
-    try {
-      if (currentFolder) {
-        const contents = await getFolderContents(currentFolder);
-        setData(contents);
-        // Update URL when folder changes
-        const newUrl = new URL(window.location.href);
-        newUrl.searchParams.set('id', currentFolder);
-        window.history.pushState({}, '', newUrl.toString());
-      } else {
-        const folders = await getTopLevelFolders();
-        setData(folders);
-        // Remove id parameter when at root
-        const newUrl = new URL(window.location.href);
-        newUrl.searchParams.delete('id');
-        window.history.pushState({}, '', newUrl.toString());
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load bookmarks');
-    } finally {
-      setIsLoading(false);
-    }
-  }, [currentFolder]);
-
-  useEffect(() => {
-    refreshCurrentFolder();
-  }, [refreshCurrentFolder]);
-
-  useEffect(() => {
-    const handleBookmarkMove = (event: CustomEvent) => {
-      if (event.detail.parentId === currentFolder) {
-        refreshCurrentFolder();
-      }
-    };
-
-    window.addEventListener('bookmarkMoved', handleBookmarkMove as EventListener);
-    return () => {
-      window.removeEventListener('bookmarkMoved', handleBookmarkMove as EventListener);
-    };
-  }, [currentFolder, refreshCurrentFolder]);
+  const { currentFolder, data, isLoading, error, navigateToFolder } =
+    useBookmarkNavigation();
 
   if (error) {
     return (
       <div className="flex h-[450px] w-full items-center justify-center">
         <div className="text-center">
-          <h2 className="text-lg font-semibold text-destructive">Error</h2>
+          <h2 className="text-lg font-semibold text-destructive">
+            {t('error_generic')}
+          </h2>
           <p className="text-sm text-muted-foreground">{error}</p>
         </div>
       </div>
@@ -246,31 +34,39 @@ export default function BookmarksPage() {
     return (
       <div className="flex h-[450px] w-full items-center justify-center">
         <div className="text-center">
-          <h2 className="text-lg font-semibold">Loading...</h2>
-          <p className="text-sm text-muted-foreground">Please wait while we load your bookmarks</p>
+          <h2 className="text-lg font-semibold">
+            {t('state_loadingSettings')}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Please wait while we load your bookmarks
+          </p>
         </div>
       </div>
     );
   }
 
   return (
-    <div className="container mx-auto py-10">
+    <div className="container mx-auto py-6 space-y-4">
+      {/* Tools Panel - collapsed by default */}
+      <div className="border rounded-lg bg-background">
+        <ToolsPanel />
+      </div>
+
+      {/* Data Table */}
       <DataTable
         columns={columns}
         data={data}
         rowClassName={(row: Bookmark) => {
           const baseClass = 'cursor-pointer hover:bg-muted/50';
           const folderClass =
-            row.type === ItemTypeEnum.Folder ? 'bg-muted/50 hover:bg-muted/70' : '';
+            row.type === ItemTypeEnum.Folder
+              ? 'bg-muted/50 hover:bg-muted/70'
+              : '';
           return `${baseClass} ${folderClass}`;
         }}
         onRowClick={(row: Bookmark) => {
           if (row.type === ItemTypeEnum.Folder) {
-            setCurrentFolder(row.id);
-            // Update URL immediately when clicking a folder
-            const newUrl = new URL(window.location.href);
-            newUrl.searchParams.set('id', row.id);
-            window.history.pushState({}, '', newUrl.toString());
+            navigateToFolder(row.id);
           }
         }}
         currentFolderId={currentFolder || undefined}
@@ -278,3 +74,7 @@ export default function BookmarksPage() {
     </div>
   );
 }
+
+// Re-export types and hooks for backwards compatibility
+export { useParentIdMap, useUrlMap } from '@/hooks/use-bookmarks-page';
+export type { Bookmark } from '@/hooks/use-bookmarks-page';

--- a/apps/extension/src/hooks/use-bookmarks-page.tsx
+++ b/apps/extension/src/hooks/use-bookmarks-page.tsx
@@ -1,0 +1,246 @@
+/**
+ * Hooks for the BookmarksPage component.
+ * Extracts navigation, folder mapping, and URL mapping logic.
+ */
+
+import { type ComponentType, useCallback, useEffect, useState } from 'react';
+import { Folder } from 'lucide-react';
+import { getFaviconUrl } from '@/services/bookmarks';
+import { type Bookmark, ItemTypeEnum } from '@/components/ui/table/columns';
+
+// Re-export for convenience
+export { type Bookmark, ItemTypeEnum } from '@/components/ui/table/columns';
+
+// Utility functions
+const formatDate = (timestamp?: number): string => {
+  if (!timestamp) return '';
+  return new Date(timestamp).toLocaleString();
+};
+
+const truncate = (text?: string, length = 50): string => {
+  if (!text) return '';
+  return text.length > length ? `${text.slice(0, length)}...` : text;
+};
+
+const processNode = (
+  node: chrome.bookmarks.BookmarkTreeNode,
+  parentId = 'Root',
+): Bookmark => {
+  const isFolder = node.children !== undefined;
+  return {
+    type: isFolder ? ItemTypeEnum.Folder : ItemTypeEnum.Link,
+    id: node.id,
+    parentId: parentId,
+    index: node.index,
+    title: truncate(node.title, 30),
+    url: truncate(node.url, 50),
+    dateAdded: formatDate(node.dateAdded),
+    dateGroupModified: formatDate(node.dateGroupModified),
+    unmodifiable: node.unmodifiable as 'managed',
+  };
+};
+
+// API functions
+async function getTopLevelFolders(): Promise<Bookmark[]> {
+  return new Promise((resolve) => {
+    if (chrome?.bookmarks) {
+      chrome.bookmarks.getTree((nodes) => {
+        const topLevelFolders =
+          nodes[0].children?.map((node) => processNode(node)) || [];
+        resolve(topLevelFolders);
+      });
+    } else {
+      resolve([]);
+    }
+  });
+}
+
+async function getFolderContents(folderId: string): Promise<Bookmark[]> {
+  return new Promise((resolve) => {
+    if (chrome?.bookmarks) {
+      chrome.bookmarks.getTree((nodes) => {
+        const findFolder = (
+          nodes: chrome.bookmarks.BookmarkTreeNode[],
+        ): chrome.bookmarks.BookmarkTreeNode | null => {
+          for (const node of nodes) {
+            if (node.id === folderId) return node;
+            if (node.children) {
+              const found = findFolder(node.children);
+              if (found) return found;
+            }
+          }
+          return null;
+        };
+
+        const targetFolder = findFolder(nodes);
+        if (targetFolder?.children) {
+          const contents = targetFolder.children.map((node) =>
+            processNode(node, folderId),
+          );
+          resolve(contents);
+        } else {
+          resolve([]);
+        }
+      });
+    } else {
+      resolve([]);
+    }
+  });
+}
+
+/**
+ * Hook for bookmark folder navigation.
+ * Handles folder state, URL sync, and data fetching.
+ */
+export function useBookmarkNavigation() {
+  const [currentFolder, setCurrentFolder] = useState<string | null>(null);
+  const [data, setData] = useState<Bookmark[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Handle initial URL parameter
+  useEffect(() => {
+    const urlParams = new URLSearchParams(window.location.search);
+    const folderId = urlParams.get('id');
+    if (folderId) {
+      setCurrentFolder(folderId);
+    }
+  }, []);
+
+  const refreshCurrentFolder = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      if (currentFolder) {
+        const contents = await getFolderContents(currentFolder);
+        setData(contents);
+        const newUrl = new URL(window.location.href);
+        newUrl.searchParams.set('id', currentFolder);
+        window.history.pushState({}, '', newUrl.toString());
+      } else {
+        const folders = await getTopLevelFolders();
+        setData(folders);
+        const newUrl = new URL(window.location.href);
+        newUrl.searchParams.delete('id');
+        window.history.pushState({}, '', newUrl.toString());
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load bookmarks');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [currentFolder]);
+
+  useEffect(() => {
+    refreshCurrentFolder();
+  }, [refreshCurrentFolder]);
+
+  // Listen for bookmark move events
+  useEffect(() => {
+    const handleBookmarkMove = (event: CustomEvent) => {
+      if (event.detail.parentId === currentFolder) {
+        refreshCurrentFolder();
+      }
+    };
+
+    window.addEventListener('bookmarkMoved', handleBookmarkMove as EventListener);
+    return () => {
+      window.removeEventListener('bookmarkMoved', handleBookmarkMove as EventListener);
+    };
+  }, [currentFolder, refreshCurrentFolder]);
+
+  const navigateToFolder = useCallback((folderId: string) => {
+    setCurrentFolder(folderId);
+    const newUrl = new URL(window.location.href);
+    newUrl.searchParams.set('id', folderId);
+    window.history.pushState({}, '', newUrl.toString());
+  }, []);
+
+  return {
+    currentFolder,
+    data,
+    isLoading,
+    error,
+    navigateToFolder,
+    refreshCurrentFolder,
+  };
+}
+
+type IconMap = Record<
+  string,
+  { value: string; label: string; icon: ComponentType<{ className?: string }> }
+>;
+
+/**
+ * Hook for parent folder ID mapping.
+ * Creates a map of folder IDs to their metadata.
+ */
+export function useParentIdMap(): IconMap {
+  const [parentIdMap, setParentIdMap] = useState<IconMap>({});
+
+  useEffect(() => {
+    if (chrome?.bookmarks) {
+      chrome.bookmarks.getTree((nodes) => {
+        const map: IconMap = {};
+
+        const processNode = (node: chrome.bookmarks.BookmarkTreeNode) => {
+          map[node.id] = {
+            value: node.id,
+            label: node.title || 'Untitled',
+            icon: Folder,
+          };
+          node.children?.forEach(processNode);
+        };
+
+        nodes.forEach(processNode);
+        setParentIdMap(map);
+      });
+    }
+  }, []);
+
+  return parentIdMap;
+}
+
+/**
+ * Hook for URL/domain mapping.
+ * Creates a map of domains to their metadata with favicons.
+ */
+export function useUrlMap(): IconMap {
+  const [urlMap, setUrlMap] = useState<IconMap>({});
+
+  useEffect(() => {
+    if (chrome?.bookmarks) {
+      chrome.bookmarks.getTree((nodes) => {
+        const map: IconMap = {};
+
+        const processNode = (node: chrome.bookmarks.BookmarkTreeNode) => {
+          if (node.children) {
+            node.children.forEach(processNode);
+          } else if (node.url) {
+            try {
+              const domain = new URL(node.url).hostname.split('.').slice(-2).join('.');
+              map[domain] = {
+                value: domain,
+                label: domain,
+                icon: () => (
+                  <img
+                    src={getFaviconUrl(node.url || '')}
+                    alt="favicon"
+                    className="w-4 h-4"
+                  />
+                ),
+              };
+            } catch {
+              // Invalid URL, skip
+            }
+          }
+        };
+
+        nodes.forEach(processNode);
+        setUrlMap(map);
+      });
+    }
+  }, []);
+
+  return urlMap;
+}


### PR DESCRIPTION
## Description
Refactors BookmarksPage for maintainability and adds a collapsible Tools panel for power-user features.

## Changes
### Phase 1: Refactoring
- Extract hooks to `use-bookmarks-page.tsx` (useBookmarkNavigation, useParentIdMap, useUrlMap)
- Simplify `BookmarksPage.tsx` from 281 → 80 lines

### Phase 2: Tools Panel
- Add collapsible `ToolsPanel.tsx` above DataTable
- Tool placeholders: Dead Link Checker, AI Reorganize, Statistics (disabled)
- i18n translations for en, ja, ko

## Type of Change
- [x] ✨ New feature
- [x] ♻️ Refactoring

## Testing
- [x] Build passes for Chrome, Firefox, Edge
- [x] Tools panel renders above DataTable
- [x] Collapsible behavior works

Closes #199