### PR TITLE
🔧 chore(github): add CODEOWNERS and stale issues workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# CODEOWNERS
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owner for everything
+* @isandrel
+
+# Extension code
+/apps/extension/ @isandrel
+
+# Documentation
+/apps/docs/ @isandrel
+
+# Website
+/apps/website/ @isandrel
+
+# CI/CD and GitHub config
+/.github/ @isandrel
+
+# Config files
+/config/ @isandrel
+/packages/ @isandrel

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,41 @@
+# Stale Issues and PRs Workflow
+# Automatically labels and closes stale issues/PRs
+
+name: 🧹 Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run daily at midnight UTC
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: |
+            👋 This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 14 days if no further activity occurs.
+            Thank you for your contributions!
+          stale-pr-message: |
+            👋 This PR has been automatically marked as stale because it has not had recent activity.
+            It will be closed in 14 days if no further activity occurs.
+            Feel free to reopen if you'd like to continue working on it!
+          close-issue-message: |
+            🔒 This issue has been automatically closed due to inactivity.
+            Feel free to reopen if this is still relevant!
+          close-pr-message: |
+            🔒 This PR has been automatically closed due to inactivity.
+            Feel free to reopen if you'd like to continue working on it!
+          days-before-stale: 60
+          days-before-close: 14
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-issue-labels: 'pinned,security,critical'
+          exempt-pr-labels: 'pinned,security,critical'
+          operations-per-run: 100


### PR DESCRIPTION
Closes #208

## Description
Adds GitHub best practices features for code ownership and issue management.

## Changes
- Add `CODEOWNERS` file for auto-requesting reviews
- Add stale workflow to auto-close inactive issues/PRs after 60 days

## Type of Change
- [x] Chore (non-breaking change that improves the project)