### PR TITLE
✨ feat(tools): add bookmark export/import functionality

### DIFF
--- a/apps/extension/public/_locales/en/messages.json
+++ b/apps/extension/public/_locales/en/messages.json
@@ -638,5 +638,45 @@
     "tools_privacyScannerDesc": {
         "message": "Detect sensitive data in URLs",
         "description": "Description for Privacy Scanner tool"
+    },
+    "tools_category_data": {
+        "message": "Data",
+        "description": "Data tools category for import/export"
+    },
+    "tools_export": {
+        "message": "Export Bookmarks",
+        "description": "Export bookmarks tool title"
+    },
+    "tools_exportDesc": {
+        "message": "Export bookmarks to HTML, JSON, Markdown, or CSV",
+        "description": "Export bookmarks tool description"
+    },
+    "tools_import": {
+        "message": "Import Bookmarks",
+        "description": "Import bookmarks tool title"
+    },
+    "tools_importDesc": {
+        "message": "Import bookmarks from HTML or JSON file",
+        "description": "Import bookmarks tool description"
+    },
+    "toast_exportSuccess": {
+        "message": "Export Complete",
+        "description": "Toast title for successful bookmark export"
+    },
+    "toast_exportSuccessDesc": {
+        "message": "$1 bookmarks exported as $2",
+        "description": "Toast description for successful bookmark export"
+    },
+    "toast_importSuccess": {
+        "message": "Import Complete",
+        "description": "Toast title for successful bookmark import"
+    },
+    "toast_importSuccessDesc": {
+        "message": "$1 items imported successfully",
+        "description": "Toast description for successful bookmark import"
+    },
+    "error_importFailed": {
+        "message": "Import failed: $1",
+        "description": "Error message for failed bookmark import"
     }
 }

--- a/apps/extension/src/hooks/use-i18n.ts
+++ b/apps/extension/src/hooks/use-i18n.ts
@@ -164,10 +164,23 @@ export type MessageKey =
   | 'tools_aiReorganizeDesc'
   | 'tools_statistics'
   | 'tools_statisticsDesc'
+  | 'tools_category_data'
+  | 'tools_export'
+  | 'tools_exportDesc'
+  | 'tools_import'
+  | 'tools_importDesc'
+  | 'toast_exportSuccess'
+  | 'toast_exportSuccessDesc'
+  | 'toast_exportFailed'
+  | 'toast_importSuccess'
+  | 'toast_importSuccessDesc'
+  | 'toast_importFailed'
+  | 'error_importFailed'
   | 'action_scan'
   | 'action_analyze'
   | 'action_view'
-  | 'action_export';
+  | 'action_export'
+  | 'action_import';
 
 /**
  * Get localized message.

--- a/apps/extension/src/services/bookmark-export.ts
+++ b/apps/extension/src/services/bookmark-export.ts
@@ -1,0 +1,278 @@
+/**
+ * Bookmark Export Service
+ * Extensible export with strategy pattern for multiple formats.
+ */
+
+import type { BookmarkTreeNode } from '@/types';
+
+// ============================================================================
+// Export Format Interface (Strategy Pattern)
+// ============================================================================
+
+export interface ExportOptions {
+  /** Include bookmark URLs (default: true) */
+  includeUrls?: boolean;
+  /** Include dates (default: false) */
+  includeDates?: boolean;
+  /** Indentation size for formatted output (default: 2) */
+  indentSize?: number;
+}
+
+export interface ExportFormat {
+  /** Display name of the format */
+  name: string;
+  /** File extension (without dot) */
+  extension: string;
+  /** MIME type for download */
+  mimeType: string;
+  /** Serialize bookmarks to string */
+  serialize(bookmarks: BookmarkTreeNode, options?: ExportOptions): string;
+}
+
+// ============================================================================
+// Built-in Format Strategies
+// ============================================================================
+
+/**
+ * Chrome/Netscape HTML format - compatible with browser import
+ */
+export const htmlFormat: ExportFormat = {
+  name: 'HTML (Chrome)',
+  extension: 'html',
+  mimeType: 'text/html',
+  serialize(node: BookmarkTreeNode, options?: ExportOptions): string {
+    const includeDates = options?.includeDates ?? false;
+
+    const escapeHtml = (text: string): string =>
+      text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+
+    const renderNode = (n: BookmarkTreeNode, depth: number): string => {
+      const indent = '    '.repeat(depth);
+
+      if (n.url) {
+        // Bookmark
+        const dateAttr = includeDates && n.dateAdded ? ` ADD_DATE="${Math.floor(n.dateAdded / 1000)}"` : '';
+        return `${indent}<DT><A HREF="${escapeHtml(n.url)}"${dateAttr}>${escapeHtml(n.title)}</A>\n`;
+      }
+
+      // Folder
+      const dateAttr = includeDates && n.dateGroupModified 
+        ? ` ADD_DATE="${Math.floor(n.dateGroupModified / 1000)}"` 
+        : '';
+      const children = n.children?.map((c) => renderNode(c, depth + 1)).join('') ?? '';
+      
+      return `${indent}<DT><H3${dateAttr}>${escapeHtml(n.title)}</H3>\n${indent}<DL><p>\n${children}${indent}</DL><p>\n`;
+    };
+
+    const content = node.children?.map((c) => renderNode(c, 1)).join('') ?? renderNode(node, 1);
+
+    return `<!DOCTYPE NETSCAPE-Bookmark-file-1>
+<!-- This is an automatically generated file.
+     It will be read and overwritten.
+     DO NOT EDIT! -->
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
+<TITLE>Bookmarks</TITLE>
+<H1>Bookmarks</H1>
+<DL><p>
+${content}</DL><p>
+`;
+  },
+};
+
+/**
+ * JSON format - preserves all data, easy to process programmatically
+ */
+export const jsonFormat: ExportFormat = {
+  name: 'JSON',
+  extension: 'json',
+  mimeType: 'application/json',
+  serialize(node: BookmarkTreeNode, options?: ExportOptions): string {
+    const indentSize = options?.indentSize ?? 2;
+    const includeDates = options?.includeDates ?? true;
+
+    const cleanNode = (n: BookmarkTreeNode): Record<string, unknown> => {
+      const result: Record<string, unknown> = {
+        title: n.title,
+      };
+
+      if (n.url) {
+        result.url = n.url;
+      }
+
+      if (includeDates) {
+        if (n.dateAdded) result.dateAdded = n.dateAdded;
+        if (n.dateGroupModified) result.dateGroupModified = n.dateGroupModified;
+      }
+
+      if (n.children && n.children.length > 0) {
+        result.children = n.children.map(cleanNode);
+      }
+
+      return result;
+    };
+
+    return JSON.stringify(cleanNode(node), null, indentSize);
+  },
+};
+
+/**
+ * Markdown format - human-readable hierarchical list
+ */
+export const markdownFormat: ExportFormat = {
+  name: 'Markdown',
+  extension: 'md',
+  mimeType: 'text/markdown',
+  serialize(node: BookmarkTreeNode, options?: ExportOptions): string {
+    const includeUrls = options?.includeUrls ?? true;
+
+    const renderNode = (n: BookmarkTreeNode, depth: number): string => {
+      const indent = '  '.repeat(depth);
+
+      if (n.url) {
+        // Bookmark as link
+        return includeUrls
+          ? `${indent}- [${n.title}](${n.url})\n`
+          : `${indent}- ${n.title}\n`;
+      }
+
+      // Folder
+      const header = depth === 0 ? `# ${n.title}\n\n` : `${indent}- **${n.title}**\n`;
+      const children = n.children?.map((c) => renderNode(c, depth + 1)).join('') ?? '';
+      return header + children;
+    };
+
+    return renderNode(node, 0);
+  },
+};
+
+/**
+ * CSV format - flat table, useful for spreadsheets
+ */
+export const csvFormat: ExportFormat = {
+  name: 'CSV',
+  extension: 'csv',
+  mimeType: 'text/csv',
+  serialize(node: BookmarkTreeNode, options?: ExportOptions): string {
+    const includeDates = options?.includeDates ?? true;
+    const rows: string[][] = [];
+
+    const escapeCsv = (text: string): string => {
+      if (text.includes(',') || text.includes('"') || text.includes('\n')) {
+        return `"${text.replace(/"/g, '""')}"`;
+      }
+      return text;
+    };
+
+    const collectRows = (n: BookmarkTreeNode, path: string): void => {
+      const currentPath = path ? `${path}/${n.title}` : n.title;
+
+      if (n.url) {
+        const row = [escapeCsv(n.title), escapeCsv(n.url), escapeCsv(path)];
+        if (includeDates && n.dateAdded) {
+          row.push(new Date(n.dateAdded).toISOString());
+        }
+        rows.push(row);
+      }
+
+      n.children?.forEach((c) => {
+        collectRows(c, currentPath);
+      });
+    };
+
+    // Header
+    const header = includeDates
+      ? ['Title', 'URL', 'Folder', 'Date Added']
+      : ['Title', 'URL', 'Folder'];
+    rows.push(header);
+
+    // Collect all bookmarks
+    collectRows(node, '');
+
+    return rows.map((row) => row.join(',')).join('\n');
+  },
+};
+
+// ============================================================================
+// Format Registry
+// ============================================================================
+
+export const exportFormats: Record<string, ExportFormat> = {
+  html: htmlFormat,
+  json: jsonFormat,
+  markdown: markdownFormat,
+  csv: csvFormat,
+};
+
+// ============================================================================
+// Export Functions
+// ============================================================================
+
+/**
+ * Get a subtree from a bookmark tree by folder ID
+ */
+export function getSubtree(
+  root: BookmarkTreeNode,
+  folderId: string
+): BookmarkTreeNode | null {
+  if (root.id === folderId) {
+    return root;
+  }
+
+  if (root.children) {
+    for (const child of root.children) {
+      const found = getSubtree(child, folderId);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Export bookmarks to a string in the specified format
+ */
+export function exportBookmarks(
+  node: BookmarkTreeNode,
+  format: ExportFormat,
+  options?: ExportOptions
+): string {
+  return format.serialize(node, options);
+}
+
+/**
+ * Trigger a file download in the browser
+ */
+export function downloadExport(
+  content: string,
+  filename: string,
+  mimeType: string
+): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Generate a filename for export
+ */
+export function generateFilename(
+  folderName: string,
+  format: ExportFormat
+): string {
+  const sanitized = folderName
+    .replace(/[^a-zA-Z0-9-_]/g, '_')
+    .replace(/_+/g, '_')
+    .substring(0, 50);
+  const date = new Date().toISOString().split('T')[0];
+  return `bookmarks_${sanitized}_${date}.${format.extension}`;
+}

--- a/apps/extension/src/services/bookmark-import.ts
+++ b/apps/extension/src/services/bookmark-import.ts
@@ -1,0 +1,321 @@
+/**
+ * Bookmark Import Service
+ * Extensible import with strategy pattern for multiple formats.
+ */
+
+import type { BookmarkTreeNode } from '@/types';
+
+// ============================================================================
+// Import Format Interface (Strategy Pattern)
+// ============================================================================
+
+export interface ImportResult {
+  /** Parsed bookmark tree */
+  bookmarks: BookmarkTreeNode[];
+  /** Number of bookmarks imported */
+  bookmarkCount: number;
+  /** Number of folders imported */
+  folderCount: number;
+}
+
+export interface ImportFormat {
+  /** Display name of the format */
+  name: string;
+  /** Supported file extensions (without dot) */
+  extensions: string[];
+  /** MIME types to accept */
+  mimeTypes: string[];
+  /** Parse content and return bookmark tree */
+  parse(content: string): BookmarkTreeNode[];
+}
+
+// ============================================================================
+// Built-in Format Parsers
+// ============================================================================
+
+/**
+ * Chrome/Netscape HTML format parser
+ */
+export const htmlImportFormat: ImportFormat = {
+  name: 'HTML (Chrome/Netscape)',
+  extensions: ['html', 'htm'],
+  mimeTypes: ['text/html'],
+  parse(content: string): BookmarkTreeNode[] {
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(content, 'text/html');
+    const result: BookmarkTreeNode[] = [];
+
+    let idCounter = 0;
+    const generateId = () => `imported-${Date.now()}-${++idCounter}`;
+
+    const parseNode = (element: Element, parentId?: string): BookmarkTreeNode | null => {
+      // Handle <A> tags (bookmarks)
+      if (element.tagName === 'A') {
+        const url = element.getAttribute('HREF');
+        const title = element.textContent?.trim() || 'Untitled';
+        const dateAdded = element.getAttribute('ADD_DATE');
+
+        return {
+          id: generateId(),
+          parentId,
+          title,
+          url: url || undefined,
+          dateAdded: dateAdded ? parseInt(dateAdded, 10) * 1000 : Date.now(),
+        };
+      }
+
+      // Handle <H3> tags (folders)
+      if (element.tagName === 'H3') {
+        const title = element.textContent?.trim() || 'Untitled Folder';
+        const dateAdded = element.getAttribute('ADD_DATE');
+        const id = generateId();
+
+        // Find the sibling <DL> that contains the folder's children
+        let sibling = element.closest('DT')?.nextElementSibling;
+        // May also be nested within the same DT
+        if (!sibling || sibling.tagName !== 'DL') {
+          sibling = element.closest('DT')?.querySelector('DL');
+        }
+
+        const children: BookmarkTreeNode[] = [];
+        if (sibling && sibling.tagName === 'DL') {
+          const dtElements = sibling.querySelectorAll(':scope > DT');
+          dtElements.forEach((dt) => {
+            const anchor = dt.querySelector(':scope > A');
+            const heading = dt.querySelector(':scope > H3');
+            if (anchor) {
+              const child = parseNode(anchor, id);
+              if (child) children.push(child);
+            } else if (heading) {
+              const child = parseNode(heading, id);
+              if (child) children.push(child);
+            }
+          });
+        }
+
+        return {
+          id,
+          parentId,
+          title,
+          dateAdded: dateAdded ? parseInt(dateAdded, 10) * 1000 : Date.now(),
+          children: children.length > 0 ? children : undefined,
+        };
+      }
+
+      return null;
+    };
+
+    // Find the main <DL> (may be nested within body or directly)
+    const mainDL = doc.querySelector('DL');
+    if (mainDL) {
+      const dtElements = mainDL.querySelectorAll(':scope > DT');
+      dtElements.forEach((dt) => {
+        const anchor = dt.querySelector(':scope > A');
+        const heading = dt.querySelector(':scope > H3');
+        if (anchor) {
+          const node = parseNode(anchor, undefined);
+          if (node) result.push(node);
+        } else if (heading) {
+          const node = parseNode(heading, undefined);
+          if (node) result.push(node);
+        }
+      });
+    }
+
+    return result;
+  },
+};
+
+/**
+ * JSON format parser
+ */
+export const jsonImportFormat: ImportFormat = {
+  name: 'JSON',
+  extensions: ['json'],
+  mimeTypes: ['application/json'],
+  parse(content: string): BookmarkTreeNode[] {
+    let idCounter = 0;
+    const generateId = () => `imported-${Date.now()}-${++idCounter}`;
+
+    interface RawNode {
+      title?: string;
+      url?: string;
+      dateAdded?: number;
+      dateGroupModified?: number;
+      children?: RawNode[];
+    }
+
+    const parseRawNode = (raw: RawNode, parentId?: string): BookmarkTreeNode => {
+      const id = generateId();
+      const node: BookmarkTreeNode = {
+        id,
+        parentId,
+        title: raw.title || 'Untitled',
+        url: raw.url,
+        dateAdded: raw.dateAdded,
+        dateGroupModified: raw.dateGroupModified,
+      };
+
+      if (raw.children && raw.children.length > 0) {
+        node.children = raw.children.map((child) => parseRawNode(child, id));
+      }
+
+      return node;
+    };
+
+    try {
+      const parsed = JSON.parse(content);
+      
+      // Handle both single object and array formats
+      if (Array.isArray(parsed)) {
+        return parsed.map((item) => parseRawNode(item, undefined));
+      }
+      
+      // Single root object
+      if (parsed.children && Array.isArray(parsed.children)) {
+        return parsed.children.map((item: RawNode) => parseRawNode(item, undefined));
+      }
+      
+      return [parseRawNode(parsed, undefined)];
+    } catch {
+      throw new Error('Invalid JSON format');
+    }
+  },
+};
+
+// ============================================================================
+// Format Registry
+// ============================================================================
+
+export const importFormats: Record<string, ImportFormat> = {
+  html: htmlImportFormat,
+  json: jsonImportFormat,
+};
+
+// ============================================================================
+// Import Functions
+// ============================================================================
+
+/**
+ * Detect format from file extension
+ */
+export function detectFormat(filename: string): ImportFormat | null {
+  const ext = filename.split('.').pop()?.toLowerCase();
+  if (!ext) return null;
+
+  for (const format of Object.values(importFormats)) {
+    if (format.extensions.includes(ext)) {
+      return format;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Parse file content and return bookmarks
+ */
+export function parseBookmarks(
+  content: string,
+  format: ImportFormat
+): ImportResult {
+  const bookmarks = format.parse(content);
+
+  // Count items
+  let bookmarkCount = 0;
+  let folderCount = 0;
+
+  const countItems = (nodes: BookmarkTreeNode[]): void => {
+    for (const node of nodes) {
+      if (node.url) {
+        bookmarkCount++;
+      } else {
+        folderCount++;
+      }
+      if (node.children) {
+        countItems(node.children);
+      }
+    }
+  };
+
+  countItems(bookmarks);
+
+  return {
+    bookmarks,
+    bookmarkCount,
+    folderCount,
+  };
+}
+
+/**
+ * Create bookmarks in Chrome from parsed structure
+ */
+export async function importBookmarks(
+  nodes: BookmarkTreeNode[],
+  targetFolderId: string
+): Promise<{ created: number; errors: string[] }> {
+  let created = 0;
+  const errors: string[] = [];
+
+  const createNode = async (
+    node: BookmarkTreeNode,
+    parentId: string
+  ): Promise<void> => {
+    try {
+      if (node.url) {
+        // Create bookmark
+        await chrome.bookmarks.create({
+          parentId,
+          title: node.title,
+          url: node.url,
+        });
+        created++;
+      } else {
+        // Create folder
+        const folder = await chrome.bookmarks.create({
+          parentId,
+          title: node.title,
+        });
+        created++;
+
+        // Recursively create children
+        if (node.children) {
+          for (const child of node.children) {
+            await createNode(child, folder.id);
+          }
+        }
+      }
+    } catch (err) {
+      errors.push(`Failed to create "${node.title}": ${err instanceof Error ? err.message : 'Unknown error'}`);
+    }
+  };
+
+  for (const node of nodes) {
+    await createNode(node, targetFolderId);
+  }
+
+  return { created, errors };
+}
+
+/**
+ * Read file and parse bookmarks
+ */
+export function readFile(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(new Error('Failed to read file'));
+    reader.readAsText(file);
+  });
+}
+
+/**
+ * Get accepted file types string for input element
+ */
+export function getAcceptedFileTypes(): string {
+  const extensions = Object.values(importFormats)
+    .flatMap((f) => f.extensions)
+    .map((ext) => `.${ext}`);
+  const mimeTypes = Object.values(importFormats).flatMap((f) => f.mimeTypes);
+  return [...new Set([...extensions, ...mimeTypes])].join(',');
+}

--- a/apps/extension/src/services/index.ts
+++ b/apps/extension/src/services/index.ts
@@ -7,3 +7,5 @@ export * from './ai-client';
 export * from './ai-models';
 export * from './ai-prompts';
 export * from './ai-recommendation';
+export * from './bookmark-export';
+export * from './bookmark-import';


### PR DESCRIPTION
## Description
Implements extensible bookmark export and import services with multiple format support.

### Export formats
- **HTML** (Chrome/Netscape Bookmark File) - Compatible with all browsers
- **JSON** - Full data preservation
- **Markdown** - Human-readable hierarchical list
- **CSV** - Spreadsheet-compatible flat format

### Import formats
- **HTML** (Chrome/Netscape) - Universal browser standard
- **JSON** - Full data restoration

### Changes
- Added `bookmark-export.ts` with strategy pattern for extensibility
- Added `bookmark-import.ts` with format parsers
- Updated `ToolsSidebar.tsx` with Data category containing Export/Import tools
- Added i18n translations for new UI elements

## Type of Change
- [x] New feature (non-breaking change)

Closes #210