### PR TITLE
♻️ refactor(export): remove hardcoded values, use config and i18n

### DIFF
--- a/apps/extension/config/settings.default.toml
+++ b/apps/extension/config/settings.default.toml
@@ -74,3 +74,17 @@ model = "gpt-4o-mini"
 
 # Auto-trigger AI recommendations when popup opens
 auto_trigger_on_open = false
+
+[export]
+# Filename settings for exported bookmark files
+filename_prefix = "bookmarks_"
+filename_max_length = 50
+
+# Indentation settings (spaces)
+json_indent_size = 2
+html_indent_spaces = 4
+markdown_indent_spaces = 2
+
+# Default export options
+include_dates_by_default = true
+include_urls_by_default = true

--- a/apps/extension/public/_locales/en/messages.json
+++ b/apps/extension/public/_locales/en/messages.json
@@ -678,5 +678,41 @@
     "error_importFailed": {
         "message": "Import failed: $1",
         "description": "Error message for failed bookmark import"
+    },
+    "export_formatHtml": {
+        "message": "HTML (Chrome)",
+        "description": "Export format name for HTML/Chrome format"
+    },
+    "export_formatJson": {
+        "message": "JSON",
+        "description": "Export format name for JSON format"
+    },
+    "export_formatMarkdown": {
+        "message": "Markdown",
+        "description": "Export format name for Markdown format"
+    },
+    "export_formatCsv": {
+        "message": "CSV",
+        "description": "Export format name for CSV format"
+    },
+    "export_htmlTitle": {
+        "message": "Bookmarks",
+        "description": "Title in exported HTML bookmark file"
+    },
+    "export_csvTitle": {
+        "message": "Title",
+        "description": "CSV header for bookmark title column"
+    },
+    "export_csvUrl": {
+        "message": "URL",
+        "description": "CSV header for bookmark URL column"
+    },
+    "export_csvFolder": {
+        "message": "Folder",
+        "description": "CSV header for bookmark folder column"
+    },
+    "export_csvDateAdded": {
+        "message": "Date Added",
+        "description": "CSV header for bookmark date added column"
     }
 }

--- a/apps/extension/src/components/bookmarks/ToolsSidebar.tsx
+++ b/apps/extension/src/components/bookmarks/ToolsSidebar.tsx
@@ -37,6 +37,7 @@ import {
   exportBookmarks,
   downloadExport,
   generateFilename,
+  getFormatName,
   parseBookmarks,
   importBookmarks,
   detectFormat,
@@ -202,7 +203,7 @@ export function ToolsSidebar({ currentFolderId, currentFolderName }: ToolsSideba
         title: t('toast_exportSuccess') || 'Export Complete',
         description: (t('toast_exportSuccessDesc') || '$1 bookmarks exported as $2')
           .replace('$1', String(count))
-          .replace('$2', format.name),
+          .replace('$2', getFormatName(format)),
       });
     } catch (err) {
       toast({
@@ -456,7 +457,7 @@ export function ToolsSidebar({ currentFolderId, currentFolderName }: ToolsSideba
                   <SelectContent>
                     {Object.entries(exportFormats).map(([key, format]) => (
                       <SelectItem key={key} value={key}>
-                        {format.name}
+                        {getFormatName(format)}
                       </SelectItem>
                     ))}
                   </SelectContent>

--- a/apps/extension/src/hooks/use-i18n.ts
+++ b/apps/extension/src/hooks/use-i18n.ts
@@ -180,7 +180,16 @@ export type MessageKey =
   | 'action_analyze'
   | 'action_view'
   | 'action_export'
-  | 'action_import';
+  | 'action_import'
+  | 'export_formatHtml'
+  | 'export_formatJson'
+  | 'export_formatMarkdown'
+  | 'export_formatCsv'
+  | 'export_htmlTitle'
+  | 'export_csvTitle'
+  | 'export_csvUrl'
+  | 'export_csvFolder'
+  | 'export_csvDateAdded';
 
 /**
  * Get localized message.

--- a/apps/extension/src/lib/settings-schema.ts
+++ b/apps/extension/src/lib/settings-schema.ts
@@ -46,6 +46,15 @@ interface TomlConfig {
     model: string;
     auto_trigger_on_open: boolean;
   };
+  export: {
+    filename_prefix: string;
+    filename_max_length: number;
+    json_indent_size: number;
+    html_indent_spaces: number;
+    markdown_indent_spaces: number;
+    include_dates_by_default: boolean;
+    include_urls_by_default: boolean;
+  };
 }
 
 const config = parse(settingsToml) as TomlConfig;
@@ -122,6 +131,15 @@ export const settingsSchema = z.object({
   aiModel: z.string().default(config.ai.model),
   aiMaxRecommendations: z.number().min(1).max(5).default(3),
   aiAutoTriggerOnOpen: z.boolean().default(config.ai.auto_trigger_on_open),
+
+  // Export - defaults from config.export
+  exportFilenamePrefix: z.string().default(config.export.filename_prefix),
+  exportFilenameMaxLength: z.number().min(10).max(100).default(config.export.filename_max_length),
+  exportJsonIndentSize: z.number().min(1).max(8).default(config.export.json_indent_size),
+  exportHtmlIndentSpaces: z.number().min(1).max(8).default(config.export.html_indent_spaces),
+  exportMarkdownIndentSpaces: z.number().min(1).max(8).default(config.export.markdown_indent_spaces),
+  exportIncludeDates: z.boolean().default(config.export.include_dates_by_default),
+  exportIncludeUrls: z.boolean().default(config.export.include_urls_by_default),
 });
 
 export type Settings = z.infer<typeof settingsSchema>;
@@ -191,6 +209,11 @@ export const settingsCategories = {
     label: 'AI',
     description: 'AI-powered folder recommendations',
     fields: ['aiEnabled', 'aiAutoTriggerOnOpen', 'aiProvider', 'aiModel', 'aiMaxRecommendations'] as const,
+  },
+  export: {
+    label: 'Export',
+    description: 'Bookmark export settings',
+    fields: ['exportFilenamePrefix', 'exportFilenameMaxLength', 'exportJsonIndentSize', 'exportIncludeDates', 'exportIncludeUrls'] as const,
   },
 } as const;
 
@@ -605,6 +628,55 @@ export const settingsFieldMeta: Record<
   aiAutoTriggerOnOpen: {
     label: 'Auto-recommend on Open',
     description: 'Automatically suggest folders when popup opens',
+    type: 'switch',
+  },
+
+  // Export
+  exportFilenamePrefix: {
+    label: 'Filename Prefix',
+    description: 'Prefix for exported bookmark files',
+    type: 'text',
+  },
+  exportFilenameMaxLength: {
+    label: 'Max Filename Length',
+    description: 'Maximum characters in exported filename',
+    type: 'number',
+    min: 10,
+    max: 100,
+    step: 5,
+  },
+  exportJsonIndentSize: {
+    label: 'JSON Indent Size',
+    description: 'Spaces for JSON formatting',
+    type: 'number',
+    min: 1,
+    max: 8,
+    step: 1,
+  },
+  exportHtmlIndentSpaces: {
+    label: 'HTML Indent Size',
+    description: 'Spaces for HTML formatting',
+    type: 'number',
+    min: 1,
+    max: 8,
+    step: 1,
+  },
+  exportMarkdownIndentSpaces: {
+    label: 'Markdown Indent Size',
+    description: 'Spaces for Markdown formatting',
+    type: 'number',
+    min: 1,
+    max: 8,
+    step: 1,
+  },
+  exportIncludeDates: {
+    label: 'Include Dates',
+    description: 'Include creation dates in exports',
+    type: 'switch',
+  },
+  exportIncludeUrls: {
+    label: 'Include URLs',
+    description: 'Include bookmark URLs in exports',
     type: 'switch',
   },
 };


### PR DESCRIPTION
## Description
Remove hardcoded strings and numbers from bookmark export service. Values are now configurable via settings and translatable via i18n.

### Changes
- Added `[export]` section to `settings.default.toml`
- Added export fields to `settingsSchema` for options page
- Added i18n keys for format names and CSV headers
- Refactored `bookmark-export.ts` to use `defaultSettings` and `t()`
- Updated `ToolsSidebar` to use `getFormatName()`

## Type of Change
- [x] Refactoring

Closes #212