### PR TITLE
🐛 fix(ai): correct Claude model IDs for Anthropic API

### DIFF
--- a/apps/extension/src/lib/settings-schema.ts
+++ b/apps/extension/src/lib/settings-schema.ts
@@ -427,8 +427,9 @@ export function getSettingsFieldMeta(): Record<
       options: [
         { value: 'gpt-5.2', label: 'GPT-5.2 (OpenAI)' },
         { value: 'gpt-4o-mini', label: 'GPT-4o Mini (OpenAI)' },
-        { value: 'claude-opus-4.5', label: 'Claude Opus 4.5 (Anthropic)' },
-        { value: 'claude-sonnet-4.5', label: 'Claude Sonnet 4.5 (Anthropic)' },
+        { value: 'claude-opus-4-20250514', label: 'Claude Opus 4 (Anthropic)' },
+        { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4 (Anthropic)' },
+        { value: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku (Anthropic)' },
         { value: 'gemini-3-flash', label: 'Gemini 3 Flash (Google)' },
         { value: 'gemini-3-pro', label: 'Gemini 3 Pro (Google)' },
       ],
@@ -628,8 +629,9 @@ export const settingsFieldMeta: Record<
     options: [
       { value: 'gpt-5.2', label: 'GPT-5.2 (OpenAI)' },
       { value: 'gpt-4o-mini', label: 'GPT-4o Mini (OpenAI)' },
-      { value: 'claude-opus-4.5', label: 'Claude Opus 4.5 (Anthropic)' },
-      { value: 'claude-sonnet-4.5', label: 'Claude Sonnet 4.5 (Anthropic)' },
+      { value: 'claude-opus-4-20250514', label: 'Claude Opus 4 (Anthropic)' },
+      { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4 (Anthropic)' },
+      { value: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku (Anthropic)' },
       { value: 'gemini-3-flash', label: 'Gemini 3 Flash (Google)' },
       { value: 'gemini-3-pro', label: 'Gemini 3 Pro (Google)' },
     ],

--- a/apps/extension/src/services/ai-models.ts
+++ b/apps/extension/src/services/ai-models.ts
@@ -23,9 +23,9 @@ export const AI_MODELS: Record<AIProvider, AIModel[]> = {
     { id: 'o1', name: 'o1', description: 'Reasoning model' },
   ],
   anthropic: [
-    { id: 'claude-opus-4.5', name: 'Claude Opus 4.5', description: 'Most intelligent' },
-    { id: 'claude-sonnet-4.5', name: 'Claude Sonnet 4.5', description: 'Best balance' },
-    { id: 'claude-haiku-4.5', name: 'Claude Haiku 4.5', description: 'Fast & cheap' },
+    { id: 'claude-opus-4-20250514', name: 'Claude Opus 4', description: 'Most intelligent' },
+    { id: 'claude-sonnet-4-20250514', name: 'Claude Sonnet 4', description: 'Best balance' },
+    { id: 'claude-3-5-haiku-20241022', name: 'Claude 3.5 Haiku', description: 'Fast & cheap' },
   ],
   google: [
     { id: 'gemini-3-pro', name: 'Gemini 3 Pro', description: 'Best reasoning' },
@@ -43,7 +43,7 @@ export function getDefaultModel(provider: AIProvider): string {
     case 'openai':
       return 'gpt-4o-mini';
     case 'anthropic':
-      return 'claude-sonnet-4.5';
+      return 'claude-sonnet-4-20250514';
     case 'google':
       return 'gemini-2.5-flash';
   }


### PR DESCRIPTION
## Description
Fix Claude AI provider not working due to incorrect model ID format.

## Changes
- Update model IDs to use correct Anthropic API format with date suffix:
  - `claude-opus-4.5` → `claude-opus-4-20250514`
  - `claude-sonnet-4.5` → `claude-sonnet-4-20250514`
  - `claude-haiku-4.5` → `claude-3-5-haiku-20241022`

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Build passes

Closes #226