### PR TITLE
✨ feat(ai): make provider configuration extensible via TOML

### DIFF
--- a/apps/extension/config/settings.default.toml
+++ b/apps/extension/config/settings.default.toml
@@ -63,13 +63,10 @@ toast_duration_ms = 4000
 # Enable AI-powered folder recommendations
 enabled = false
 
-# AI provider: "openai", "anthropic", or "google"
+# Default AI provider: "openai", "anthropic", or "google"
 provider = "openai"
 
-# Model to use (provider-specific)
-# OpenAI: gpt-4o-mini, gpt-4o
-# Anthropic: claude-3-haiku-20240307, claude-3-5-sonnet-20241022
-# Google: gemini-1.5-flash, gemini-1.5-pro
+# Default model to use (must match a model id from providers below)
 model = "gpt-4o-mini"
 
 # Auto-trigger AI recommendations when popup opens
@@ -79,6 +76,84 @@ auto_trigger_on_open = false
 max_categories       = -1
 max_items_per_folder = -1
 min_items_per_folder = 1
+
+# ============================================================================
+# AI Providers Configuration
+# Add or modify providers and their models here for extensibility.
+# Each provider needs: id, name, default_model, and a list of models.
+# ============================================================================
+
+[ai.providers.openai]
+name = "OpenAI"
+default_model = "gpt-4o-mini"
+
+[[ai.providers.openai.models]]
+id = "gpt-4o-mini"
+name = "GPT-4o Mini"
+description = "Cost-effective"
+
+[[ai.providers.openai.models]]
+id = "gpt-4o"
+name = "GPT-4o"
+description = "Multimodal flagship"
+
+[[ai.providers.openai.models]]
+id = "gpt-5"
+name = "GPT-5"
+description = "Most capable"
+
+[[ai.providers.openai.models]]
+id = "gpt-5-mini"
+name = "GPT-5 Mini"
+description = "Fast & efficient"
+
+[[ai.providers.openai.models]]
+id = "o1"
+name = "o1"
+description = "Reasoning model"
+
+[ai.providers.anthropic]
+name = "Anthropic"
+default_model = "claude-sonnet-4-20250514"
+
+[[ai.providers.anthropic.models]]
+id = "claude-sonnet-4-20250514"
+name = "Claude Sonnet 4"
+description = "Best balance"
+
+[[ai.providers.anthropic.models]]
+id = "claude-opus-4-20250514"
+name = "Claude Opus 4"
+description = "Most intelligent"
+
+[[ai.providers.anthropic.models]]
+id = "claude-3-5-haiku-20241022"
+name = "Claude 3.5 Haiku"
+description = "Fast & cheap"
+
+[ai.providers.google]
+name = "Google"
+default_model = "gemini-2.5-flash"
+
+[[ai.providers.google.models]]
+id = "gemini-2.5-flash"
+name = "Gemini 2.5 Flash"
+description = "Cost-effective"
+
+[[ai.providers.google.models]]
+id = "gemini-2.5-pro"
+name = "Gemini 2.5 Pro"
+description = "2M context"
+
+[[ai.providers.google.models]]
+id = "gemini-3-flash"
+name = "Gemini 3 Flash"
+description = "Fast frontier"
+
+[[ai.providers.google.models]]
+id = "gemini-3-pro"
+name = "Gemini 3 Pro"
+description = "Best reasoning"
 
 # Custom prompts (leave empty to use defaults)
 # Users can edit in options page

--- a/apps/extension/src/lib/settings-schema.ts
+++ b/apps/extension/src/lib/settings-schema.ts
@@ -6,6 +6,8 @@
 import { z } from 'zod';
 import { parse } from 'smol-toml';
 import { t } from '@/hooks/use-i18n';
+import { getAvailableProviders, getModelsForProvider, getProviderName } from '@/services/ai-models';
+import type { AIProvider } from '@/services/ai-client';
 
 // Import TOML config as raw string (bundled at build time)
 import settingsToml from '../../config/settings.default.toml?raw';
@@ -414,25 +416,19 @@ export function getSettingsFieldMeta(): Record<
       label: 'AI Provider',
       description: 'Choose your AI provider',
       type: 'select',
-      options: [
-        { value: 'openai', label: 'OpenAI' },
-        { value: 'anthropic', label: 'Anthropic' },
-        { value: 'google', label: 'Google' },
-      ],
+      options: getAvailableProviders().map((p) => ({ value: p.id, label: p.name })),
     },
     aiModel: {
       label: 'Model',
       description: 'AI model to use',
       type: 'select',
-      options: [
-        { value: 'gpt-5.2', label: 'GPT-5.2 (OpenAI)' },
-        { value: 'gpt-4o-mini', label: 'GPT-4o Mini (OpenAI)' },
-        { value: 'claude-opus-4-20250514', label: 'Claude Opus 4 (Anthropic)' },
-        { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4 (Anthropic)' },
-        { value: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku (Anthropic)' },
-        { value: 'gemini-3-flash', label: 'Gemini 3 Flash (Google)' },
-        { value: 'gemini-3-pro', label: 'Gemini 3 Pro (Google)' },
-      ],
+      // Note: This shows all models; UI should filter based on selected provider
+      options: (['openai', 'anthropic', 'google'] as const).flatMap((provider) =>
+        getModelsForProvider(provider).map((m) => ({
+          value: m.id,
+          label: `${m.name} (${getProviderName(provider)})`,
+        }))
+      ),
     },
     aiMaxRecommendations: {
       label: 'Max Recommendations',
@@ -616,25 +612,19 @@ export const settingsFieldMeta: Record<
     label: 'AI Provider',
     description: 'Choose your AI provider',
     type: 'select',
-    options: [
-      { value: 'openai', label: 'OpenAI' },
-      { value: 'anthropic', label: 'Anthropic' },
-      { value: 'google', label: 'Google' },
-    ],
+    options: getAvailableProviders().map((p) => ({ value: p.id, label: p.name })),
   },
   aiModel: {
     label: 'Model',
     description: 'AI model to use',
     type: 'select',
-    options: [
-      { value: 'gpt-5.2', label: 'GPT-5.2 (OpenAI)' },
-      { value: 'gpt-4o-mini', label: 'GPT-4o Mini (OpenAI)' },
-      { value: 'claude-opus-4-20250514', label: 'Claude Opus 4 (Anthropic)' },
-      { value: 'claude-sonnet-4-20250514', label: 'Claude Sonnet 4 (Anthropic)' },
-      { value: 'claude-3-5-haiku-20241022', label: 'Claude 3.5 Haiku (Anthropic)' },
-      { value: 'gemini-3-flash', label: 'Gemini 3 Flash (Google)' },
-      { value: 'gemini-3-pro', label: 'Gemini 3 Pro (Google)' },
-    ],
+    // Note: This shows all models; UI should filter based on selected provider
+    options: (['openai', 'anthropic', 'google'] as AIProvider[]).flatMap((provider) =>
+      getModelsForProvider(provider).map((m) => ({
+        value: m.id,
+        label: `${m.name} (${getProviderName(provider)})`,
+      }))
+    ),
   },
   aiMaxRecommendations: {
     label: 'Max Recommendations',

--- a/apps/extension/src/services/ai-models.ts
+++ b/apps/extension/src/services/ai-models.ts
@@ -1,9 +1,11 @@
 /**
  * AI Model Configuration.
- * Provider-specific model lists for dynamic dropdown.
+ * Provider-specific model lists loaded from TOML config for extensibility.
  */
 
+import { parse } from 'smol-toml';
 import type { AIProvider } from './ai-client';
+import settingsToml from '../../config/settings.default.toml?raw';
 
 export interface AIModel {
   id: string;
@@ -11,34 +13,62 @@ export interface AIModel {
   description?: string;
 }
 
-/**
- * Models available for each provider (December 2025).
- */
-export const AI_MODELS: Record<AIProvider, AIModel[]> = {
-  openai: [
-    { id: 'gpt-5', name: 'GPT-5', description: 'Most capable model' },
-    { id: 'gpt-5-mini', name: 'GPT-5 Mini', description: 'Fast & efficient' },
-    { id: 'gpt-4o', name: 'GPT-4o', description: 'Multimodal flagship' },
-    { id: 'gpt-4o-mini', name: 'GPT-4o Mini', description: 'Cost-effective' },
-    { id: 'o1', name: 'o1', description: 'Reasoning model' },
-  ],
-  anthropic: [
-    { id: 'claude-opus-4-20250514', name: 'Claude Opus 4', description: 'Most intelligent' },
-    { id: 'claude-sonnet-4-20250514', name: 'Claude Sonnet 4', description: 'Best balance' },
-    { id: 'claude-3-5-haiku-20241022', name: 'Claude 3.5 Haiku', description: 'Fast & cheap' },
-  ],
-  google: [
-    { id: 'gemini-3-pro', name: 'Gemini 3 Pro', description: 'Best reasoning' },
-    { id: 'gemini-3-flash', name: 'Gemini 3 Flash', description: 'Fast frontier' },
-    { id: 'gemini-2.5-flash', name: 'Gemini 2.5 Flash', description: 'Cost-effective' },
-    { id: 'gemini-2.5-pro', name: 'Gemini 2.5 Pro', description: '2M context' },
-  ],
-};
+interface ProviderConfig {
+  name: string;
+  default_model: string;
+  models: AIModel[];
+}
+
+interface AIConfig {
+  providers: Record<string, ProviderConfig>;
+}
+
+interface TomlConfig {
+  ai: AIConfig;
+}
+
+// Parse config at module load time
+const config = parse(settingsToml) as unknown as TomlConfig;
 
 /**
- * Get default model for a provider.
+ * Get all available provider IDs from config.
+ */
+export function getAvailableProviders(): { id: AIProvider; name: string }[] {
+  const providers = config.ai?.providers || {};
+  return Object.entries(providers).map(([id, provider]) => ({
+    id: id as AIProvider,
+    name: provider.name,
+  }));
+}
+
+/**
+ * Models available for each provider (loaded from TOML config).
+ */
+export const AI_MODELS: Record<AIProvider, AIModel[]> = (() => {
+  const providers = config.ai?.providers || {};
+  const result: Record<string, AIModel[]> = {};
+
+  for (const [providerId, provider] of Object.entries(providers)) {
+    result[providerId] = provider.models || [];
+  }
+
+  // Ensure all expected providers exist (fallback to empty arrays)
+  return {
+    openai: result.openai || [],
+    anthropic: result.anthropic || [],
+    google: result.google || [],
+  };
+})();
+
+/**
+ * Get default model for a provider (from TOML config).
  */
 export function getDefaultModel(provider: AIProvider): string {
+  const providerConfig = config.ai?.providers?.[provider];
+  if (providerConfig?.default_model) {
+    return providerConfig.default_model;
+  }
+  // Fallback defaults if config is missing
   switch (provider) {
     case 'openai':
       return 'gpt-4o-mini';
@@ -54,4 +84,11 @@ export function getDefaultModel(provider: AIProvider): string {
  */
 export function getModelsForProvider(provider: AIProvider): AIModel[] {
   return AI_MODELS[provider] || [];
+}
+
+/**
+ * Get provider display name.
+ */
+export function getProviderName(provider: AIProvider): string {
+  return config.ai?.providers?.[provider]?.name || provider;
 }


### PR DESCRIPTION
## Description
Move hardcoded AI model lists to `settings.default.toml` for easier configuration and extensibility.

## Changes
- **settings.default.toml**: Add structured `[ai.providers.*]` sections with:
  - `name`: Provider display name
  - `default_model`: Default model for the provider
  - `models`: Array of available models (id, name, description)
- **ai-models.ts**: Refactored to load providers/models from TOML config
  - Added `getAvailableProviders()` and `getProviderName()` helpers
- **settings-schema.ts**: Dynamically generate provider/model options from config

## Benefits
- Add new models by editing TOML config (no code changes)
- Update model IDs without touching TypeScript
- Extensible provider system

## Type of Change
- [x] ✨ New feature (non-breaking change which adds functionality)

## Testing
- [x] Build passes (`bun run build`)

Closes #228