### PR TITLE
📝 docs(website): update installation to download from releases

### DIFF
--- a/apps/website/app/[locale]/page.tsx
+++ b/apps/website/app/[locale]/page.tsx
@@ -224,12 +224,18 @@ export default async function Home({
                                 </span>
                                 {t("installation.step1.title")}
                             </h3>
-                            <pre className="bg-black/50 rounded-lg p-4 overflow-x-auto">
-                                <code className="text-sm text-green-400">
-                                    git clone {GITHUB_URL}.git{"\n"}
-                                    cd bookmark-scout
-                                </code>
-                            </pre>
+                            <p className="text-muted mb-4">{t("installation.step1.description")}</p>
+                            <a
+                                href={`${GITHUB_URL}/releases/latest`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-2 rounded-full bg-linear-to-r from-primary to-accent px-6 py-3 font-medium text-white shadow-lg hover:shadow-xl transition-all"
+                            >
+                                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                                    <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+                                </svg>
+                                Download Latest Release
+                            </a>
                         </div>
 
                         <div className="glass rounded-2xl p-6">
@@ -239,12 +245,7 @@ export default async function Home({
                                 </span>
                                 {t("installation.step2.title")}
                             </h3>
-                            <pre className="bg-black/50 rounded-lg p-4 overflow-x-auto">
-                                <code className="text-sm text-green-400">
-                                    bun install{"\n"}
-                                    bun run build
-                                </code>
-                            </pre>
+                            <p className="text-muted">{t("installation.step2.description")}</p>
                         </div>
 
                         <div className="glass rounded-2xl p-6">

--- a/apps/website/messages/en.json
+++ b/apps/website/messages/en.json
@@ -56,10 +56,12 @@
         "title": "Installation",
         "subtitle": "Get started in minutes",
         "step1": {
-            "title": "Clone the repository"
+            "title": "Download from GitHub Releases",
+            "description": "Download the latest release ZIP file for your browser"
         },
         "step2": {
-            "title": "Install dependencies & build"
+            "title": "Extract the ZIP file",
+            "description": "Unzip the downloaded file to a folder"
         },
         "step3": {
             "title": "Load in Chrome",
@@ -67,7 +69,7 @@
                 "1": "Open chrome://extensions/",
                 "2": "Enable Developer mode (top right)",
                 "3": "Click Load unpacked",
-                "4": "Select the dist folder"
+                "4": "Select the extracted folder"
             }
         }
     },


### PR DESCRIPTION
## Summary
Update the website installation section to guide users to download from GitHub releases instead of building from source.

## Changes
- Changed installation steps from source build to release download
- Added "Download Latest Release" button linking to GitHub releases page
- Updated step descriptions for simpler user experience

## Why
- Most users just want to install the extension, not build from source
- Releases page provides ready-to-use ZIP files for all browsers