### PR TITLE
🔧 chore: add version numbers to release asset filenames

### DIFF
--- a/.github/workflows/release-extension.yml
+++ b/.github/workflows/release-extension.yml
@@ -39,31 +39,6 @@ jobs:
         run: bun run build:edge
         working-directory: ./apps/extension
 
-      - name: Create Chrome zip
-        run: |
-          cd dist/chrome-mv3
-          zip -r ../../bookmark-scout-chrome.zip .
-        working-directory: ./apps/extension
-
-      - name: Create Firefox zip
-        run: |
-          cd dist/firefox-mv2
-          zip -r ../../bookmark-scout-firefox.zip .
-        working-directory: ./apps/extension
-
-      - name: Create Edge zip
-        run: |
-          cd dist/edge-mv3
-          zip -r ../../bookmark-scout-edge.zip .
-        working-directory: ./apps/extension
-
-      - name: Build Chrome CRX
-        uses: cardinalby/webext-buildtools-chrome-crx-action@v2
-        with:
-          zipFilePath: apps/extension/bookmark-scout-chrome.zip
-          crxFilePath: apps/extension/bookmark-scout-chrome.crx
-          privateKey: ${{ secrets.CRX_PRIVATE_KEY }}
-
       - name: Get version from tag
         id: get_version
         run: |
@@ -72,6 +47,31 @@ jobs:
           else
             echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Create Chrome zip
+        run: |
+          cd dist/chrome-mv3
+          zip -r ../../bookmark-scout-${{ steps.get_version.outputs.version }}-chrome.zip .
+        working-directory: ./apps/extension
+
+      - name: Create Firefox zip
+        run: |
+          cd dist/firefox-mv2
+          zip -r ../../bookmark-scout-${{ steps.get_version.outputs.version }}-firefox.zip .
+        working-directory: ./apps/extension
+
+      - name: Create Edge zip
+        run: |
+          cd dist/edge-mv3
+          zip -r ../../bookmark-scout-${{ steps.get_version.outputs.version }}-edge.zip .
+        working-directory: ./apps/extension
+
+      - name: Build Chrome CRX
+        uses: cardinalby/webext-buildtools-chrome-crx-action@v2
+        with:
+          zipFilePath: apps/extension/bookmark-scout-${{ steps.get_version.outputs.version }}-chrome.zip
+          crxFilePath: apps/extension/bookmark-scout-${{ steps.get_version.outputs.version }}-chrome.crx
+          privateKey: ${{ secrets.CRX_PRIVATE_KEY }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -83,10 +83,10 @@ jobs:
 
             | Browser | File | Description |
             |---------|------|-------------|
-            | Chrome | `bookmark-scout-chrome.crx` | Signed extension (sideload) |
-            | Chrome | `bookmark-scout-chrome.zip` | For Chrome Web Store |
-            | Firefox | `bookmark-scout-firefox.zip` | For Firefox Add-ons |
-            | Edge | `bookmark-scout-edge.zip` | For Edge Add-ons |
+            | Chrome | `bookmark-scout-${{ steps.get_version.outputs.version }}-chrome.crx` | Signed extension (sideload) |
+            | Chrome | `bookmark-scout-${{ steps.get_version.outputs.version }}-chrome.zip` | For Chrome Web Store |
+            | Firefox | `bookmark-scout-${{ steps.get_version.outputs.version }}-firefox.zip` | For Firefox Add-ons |
+            | Edge | `bookmark-scout-${{ steps.get_version.outputs.version }}-edge.zip` | For Edge Add-ons |
 
             ## Installation
 
@@ -108,10 +108,10 @@ jobs:
             3. Enable "Developer mode"
             4. Click "Load unpacked" and select the extracted folder
           files: |
-            apps/extension/bookmark-scout-chrome.crx
-            apps/extension/bookmark-scout-chrome.zip
-            apps/extension/bookmark-scout-firefox.zip
-            apps/extension/bookmark-scout-edge.zip
+            apps/extension/bookmark-scout-${{ steps.get_version.outputs.version }}-chrome.crx
+            apps/extension/bookmark-scout-${{ steps.get_version.outputs.version }}-chrome.zip
+            apps/extension/bookmark-scout-${{ steps.get_version.outputs.version }}-firefox.zip
+            apps/extension/bookmark-scout-${{ steps.get_version.outputs.version }}-edge.zip
           generate_release_notes: true
           draft: false
           prerelease: false


### PR DESCRIPTION
Closes #243

## Description
This PR updates the release workflow to include version numbers in all asset filenames, following the industry best practice format: `[project]-[version]-[platform].[ext]`

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Chore (maintenance task, dependency update, etc.)

## Changes Made
- Moved "Get version from tag" step before asset creation
- Updated Chrome zip filename to include version: `bookmark-scout-${{ steps.get_version.outputs.version }}-chrome.zip`
- Updated Firefox zip filename to include version: `bookmark-scout-${{ steps.get_version.outputs.version }}-firefox.zip`
- Updated Edge zip filename to include version: `bookmark-scout-${{ steps.get_version.outputs.version }}-edge.zip`
- Updated Chrome CRX filename to include version: `bookmark-scout-${{ steps.get_version.outputs.version }}-chrome.crx`
- Updated release notes table to reflect versioned filenames
- Updated files list in release action to reference versioned filenames

## Example Output
For tag `v0.1.3`, the assets will be named:
- `bookmark-scout-v0.1.3-chrome.crx`
- `bookmark-scout-v0.1.3-chrome.zip`
- `bookmark-scout-v0.1.3-firefox.zip`
- `bookmark-scout-v0.1.3-edge.zip`

## Testing
This change can be tested by:
1. Creating a test tag and triggering the workflow
2. Verifying the generated asset filenames include the version
3. Confirming the release notes table displays correct filenames

## Benefits
- Users can easily identify which version they downloaded
- Better asset management when storing multiple versions locally
- Follows GitHub release asset naming best practices