### PR TITLE
Add AI provider routing controls

### DIFF
--- a/apps/extension/src/components/bookmarks/ToolsSidebar.tsx
+++ b/apps/extension/src/components/bookmarks/ToolsSidebar.tsx
@@ -505,22 +505,7 @@ export function ToolsSidebar({ currentFolderId, currentFolderName }: ToolsSideba
       
       try {
         const targetFolders = getTargetNodes(scope);
-        
-        const { aiApiKey } = await chrome.storage.local.get('aiApiKey');
-        
-        if (!aiApiKey && aiProvider !== 'ollama') {
-          setReorgErrors(['API key not configured. Please set it in Options → AI.']);
-          setReorgLoading(false);
-          return;
-        }
-
-        const aiSettings = {
-          enabled: aiEnabled,
-          provider: aiProvider as AIProvider,
-          model: aiModel,
-          apiKey: aiApiKey as string,
-        };
-        
+        const aiSettings = await buildAISettings();
         const plan = await generateReorganizationPlan(targetFolders, aiSettings);
         setReorgPlan(plan);
       } catch (err) {

--- a/apps/extension/src/components/page/OptionsPage.tsx
+++ b/apps/extension/src/components/page/OptionsPage.tsx
@@ -16,6 +16,7 @@ import {
 	ShieldAlert,
 	Moon,
 	Palette,
+	RefreshCw,
 	RotateCcw,
 	Save,
 	Search,
@@ -23,6 +24,7 @@ import {
 	Sliders,
 	Sparkles,
 	Sun,
+	Wifi,
 	Upload,
 	Wrench,
 } from "lucide-react";
@@ -66,11 +68,14 @@ import {
 	importSettings,
 } from "@/lib/settings-storage";
 import {
+	buildAISettingsFromProvider,
+	detectAIModels,
 	getModelsForProvider,
 	getProviderConfig,
 	providerRequiresApiKey,
 	providerSupportsCustomModel,
 	type AIProvider,
+	verifyAIService,
 } from "@/services";
 import {
 	getStoredAIProviderConfig,
@@ -110,6 +115,9 @@ const OptionsPage: React.FC = () => {
 	const [providerBaseUrl, setProviderBaseUrl] = useState("");
 	const [providerCustomModel, setProviderCustomModel] = useState("");
 	const [providerExtraHeaders, setProviderExtraHeaders] = useState("");
+	const [isVerifyingProvider, setIsVerifyingProvider] = useState(false);
+	const [isDetectingModels, setIsDetectingModels] = useState(false);
+	const [detectedModels, setDetectedModels] = useState<Record<string, string[]>>({});
 
 	const form = useForm<Settings>({
 		resolver: zodResolver(settingsSchema) as never,
@@ -166,11 +174,6 @@ const OptionsPage: React.FC = () => {
 		if (!providerRequiresApiKey(provider)) {
 			await saveStoredAIProviderConfig(provider, { apiKey: key });
 			setApiKey(key);
-			toast({
-				title: "✓ Settings Saved",
-				description: `${providerConfig?.name || provider} settings saved.`,
-				variant: "success",
-			});
 			return;
 		}
 
@@ -197,9 +200,31 @@ const OptionsPage: React.FC = () => {
 
 	const saveProviderOverrides = async () => {
 		const provider = selectedProvider;
-		if (!providerBaseUrl.trim() && !providerCustomModel.trim() && !providerExtraHeaders.trim()) {
+		if (!apiKey.trim() && !providerBaseUrl.trim() && !providerCustomModel.trim() && !providerExtraHeaders.trim()) {
 			await clearStoredAIProviderConfig(provider);
 			return;
+		}
+
+		if (providerExtraHeaders.trim()) {
+			try {
+				const parsed = JSON.parse(providerExtraHeaders) as unknown;
+				const isStringRecord =
+					parsed !== null &&
+					typeof parsed === "object" &&
+					!Array.isArray(parsed) &&
+					Object.values(parsed).every((value) => typeof value === "string");
+
+				if (!isStringRecord) {
+					throw new Error("Extra headers must be a JSON object with string values.");
+				}
+			} catch {
+				toast({
+					title: "Invalid extra headers",
+					description: 'Use JSON object syntax, for example: {"HTTP-Referer":"https://example.com"}',
+					variant: "destructive",
+				});
+				return;
+			}
 		}
 
 		await saveStoredAIProviderConfig(provider, {
@@ -208,6 +233,60 @@ const OptionsPage: React.FC = () => {
 			customModel: providerCustomModel,
 			extraHeaders: providerExtraHeaders,
 		});
+	};
+
+	const buildSelectedAISettings = () =>
+		buildAISettingsFromProvider(selectedProvider, form.getValues("aiModel"), true);
+
+	const verifyProviderConnection = async () => {
+		setIsVerifyingProvider(true);
+		try {
+			await saveProviderOverrides();
+			await verifyAIService(await buildSelectedAISettings());
+			toast({
+				title: "Service verified",
+				description: `${getProviderConfig(selectedProvider)?.name || selectedProvider} responded successfully.`,
+				variant: "success",
+			});
+		} catch (error) {
+			toast({
+				title: "Service verification failed",
+				description: error instanceof Error ? error.message : "Provider did not respond successfully.",
+				variant: "destructive",
+			});
+		} finally {
+			setIsVerifyingProvider(false);
+		}
+	};
+
+	const refreshProviderModels = async () => {
+		setIsDetectingModels(true);
+		try {
+			await saveProviderOverrides();
+			const models = await detectAIModels(await buildSelectedAISettings());
+			if (models.length === 0) {
+				throw new Error("Provider returned no models.");
+			}
+
+			setDetectedModels((current) => ({
+				...current,
+				[selectedProvider]: models.map((model) => model.id),
+			}));
+			form.setValue("aiModel", models[0].id);
+			toast({
+				title: "Models refreshed",
+				description: `${models.length} models detected from ${getProviderConfig(selectedProvider)?.name || selectedProvider}.`,
+				variant: "success",
+			});
+		} catch (error) {
+			toast({
+				title: "Model detection failed",
+				description: error instanceof Error ? error.message : "Provider models could not be detected.",
+				variant: "destructive",
+			});
+		} finally {
+			setIsDetectingModels(false);
+		}
 	};
 
 	const providerDescription = providerRequiresApiKey(selectedProvider)
@@ -238,12 +317,6 @@ const OptionsPage: React.FC = () => {
 				if (values.theme !== theme) {
 					setTheme(values.theme);
 				}
-				toast({
-					title: `✓ ${t("toast_settingsSaved")}`,
-					description: t("toast_preferencesUpdated"),
-					variant: "success",
-					duration: 2000, // Short duration for auto-save
-				});
 			} catch (error) {
 				toast({
 					title: `× ${t("toast_errorSavingSettings")}`,
@@ -390,8 +463,10 @@ const OptionsPage: React.FC = () => {
 				let selectOptions = meta.options;
 				if (fieldKey === "aiModel") {
 					const provider = form.watch("aiProvider") as AIProvider;
-					const models = getModelsForProvider(provider);
-					selectOptions = models.map((m) => ({ value: m.id, label: m.name }));
+					const detected = detectedModels[provider];
+					selectOptions = detected?.length
+						? detected.map((id) => ({ value: id, label: id }))
+						: getModelsForProvider(provider).map((model) => ({ value: model.id, label: model.name }));
 				}
 
 				return (
@@ -586,7 +661,7 @@ const OptionsPage: React.FC = () => {
 									onValueChange={setActiveTab}
 									className="w-full"
 								>
-									<TabsList className="mb-6 flex w-full flex-wrap justify-start gap-2 bg-transparent p-0">
+									<TabsList className="mb-6 flex h-auto w-full flex-wrap justify-start gap-2 bg-transparent p-0">
 										{Object.entries(categories).map(
 											([key, category]) => (
 												<TabsTrigger
@@ -681,7 +756,6 @@ const OptionsPage: React.FC = () => {
 																onBlur={(e) => saveApiKey(e.target.value)}
 																placeholder={providerPlaceholder}
 																className="w-[200px] pr-8"
-																disabled={!providerRequiresApiKey(selectedProvider)}
 															/>
 															<Button
 																type="button"
@@ -689,7 +763,6 @@ const OptionsPage: React.FC = () => {
 																size="icon"
 																className="absolute right-0 top-0 h-full w-8"
 																onClick={() => setShowApiKey(!showApiKey)}
-																disabled={!providerRequiresApiKey(selectedProvider)}
 															>
 																{showApiKey ? (
 																	<EyeOff className="h-4 w-4" />
@@ -749,6 +822,26 @@ const OptionsPage: React.FC = () => {
 															onBlur={saveProviderOverrides}
 															placeholder='{"HTTP-Referer":"https://example.com"}'
 														/>
+														<div className="flex flex-wrap gap-2">
+															<Button
+																type="button"
+																variant="outline"
+																onClick={refreshProviderModels}
+																disabled={isDetectingModels}
+															>
+																<RefreshCw className="h-4 w-4 mr-2" />
+																{isDetectingModels ? "Refreshing..." : "Refresh Models"}
+															</Button>
+															<Button
+																type="button"
+																variant="outline"
+																onClick={verifyProviderConnection}
+																disabled={isVerifyingProvider}
+															>
+																<Wifi className="h-4 w-4 mr-2" />
+																{isVerifyingProvider ? "Verifying..." : "Verify Service"}
+															</Button>
+														</div>
 													</motion.div>
 											</>
 										)}

--- a/apps/extension/src/lib/settings-schema.ts
+++ b/apps/extension/src/lib/settings-schema.ts
@@ -182,6 +182,11 @@ interface TomlConfig {
 
 const config = parse(settingsToml) as TomlConfig;
 
+const configuredProviderIds = Object.keys(config.ai.providers ?? {});
+const aiProviderSchema = configuredProviderIds.length > 0
+  ? z.enum(configuredProviderIds as [AIProvider, ...AIProvider[]])
+  : z.enum(['openai']);
+
 export const themeSchema = z.enum(['system', 'light', 'dark']);
 export type Theme = z.infer<typeof themeSchema>;
 
@@ -237,7 +242,7 @@ export const settingsSchema = z.object({
   toastDurationMs: z.number().min(2000).max(10000).default(config.advanced.toast_duration_ms),
 
   aiEnabled: z.boolean().default(config.ai.enabled),
-  aiProvider: z.enum(['openai', 'anthropic', 'google', 'groq', 'mistral', 'deepseek', 'ollama']).default(config.ai.provider as AIProvider),
+  aiProvider: aiProviderSchema.default(config.ai.provider as AIProvider),
   aiModel: z.string().default(config.ai.model),
   aiMaxRecommendations: z.number().min(1).max(10).default(config.tools.auto_tagging.max_tags),
   aiAutoTriggerOnOpen: z.boolean().default(config.ai.auto_trigger_on_open),
@@ -593,10 +598,10 @@ function buildFieldMeta(): Record<keyof Settings, SettingsFieldMeta> {
       label: t('settings_aiModel'),
       description: t('settings_aiModelDesc'),
       type: 'select',
-      options: (['openai', 'anthropic', 'google', 'groq', 'mistral', 'deepseek', 'ollama'] as AIProvider[]).flatMap((provider) =>
-        getModelsForProvider(provider).map((model) => ({
+      options: getAvailableProviders().flatMap((provider) =>
+        getModelsForProvider(provider.id).map((model) => ({
           value: model.id,
-          label: `${model.name} (${getProviderName(provider)})`,
+          label: `${model.name} (${getProviderName(provider.id)})`,
         })),
       ),
     },

--- a/apps/extension/src/services/ai-client.ts
+++ b/apps/extension/src/services/ai-client.ts
@@ -8,6 +8,7 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createGroq } from '@ai-sdk/groq';
 import { createMistral } from '@ai-sdk/mistral';
 import { createOpenAI } from '@ai-sdk/openai';
+import { generateText } from 'ai';
 import { createOllama } from 'ollama-ai-provider';
 import {
   getDefaultModel,
@@ -37,6 +38,11 @@ export type AISettings = {
   baseUrl?: string;
   customModel?: string;
   extraHeaders?: Record<string, string>;
+};
+
+export type DetectedAIModel = {
+  id: string;
+  name: string;
 };
 
 export const defaultAISettings: AISettings = {
@@ -86,6 +92,69 @@ export function validateAISettings(settings: AISettings): void {
   if (!settings.model && !settings.customModel) {
     throw new Error('Model is required');
   }
+}
+
+export async function verifyAIService(settings: AISettings): Promise<void> {
+  const model = createAIModel(settings);
+  await generateText({
+    model,
+    maxOutputTokens: 8,
+    prompt: 'Reply with exactly: ok',
+  });
+}
+
+export async function detectAIModels(settings: AISettings): Promise<DetectedAIModel[]> {
+  const baseUrl = getModelListBaseUrl(settings);
+  if (!baseUrl) {
+    throw new Error('Model detection is not available for this provider. Use a custom model instead.');
+  }
+
+  const url = new URL('models', baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`);
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    ...settings.extraHeaders,
+  };
+
+  if (settings.apiKey) {
+    headers.Authorization = `Bearer ${settings.apiKey}`;
+  }
+
+  if (settings.provider === 'anthropic') {
+    headers['x-api-key'] = settings.apiKey;
+    headers['anthropic-version'] = '2023-06-01';
+    delete headers.Authorization;
+  }
+
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    throw new Error(`Model detection failed: ${response.status} ${response.statusText}`);
+  }
+
+  const payload = await response.json() as { data?: unknown };
+  const data = Array.isArray(payload.data) ? payload.data : [];
+
+  return data
+    .map((item) => {
+      if (!item || typeof item !== 'object' || !('id' in item)) {
+        return null;
+      }
+
+      const id = String(item.id);
+      return { id, name: id };
+    })
+    .filter((model): model is DetectedAIModel => model !== null);
+}
+
+function getModelListBaseUrl(settings: AISettings): string | undefined {
+  if (settings.provider === 'openai') {
+    return settings.baseUrl || 'https://api.openai.com/v1';
+  }
+
+  if (settings.provider === 'anthropic') {
+    return settings.baseUrl || 'https://api.anthropic.com/v1';
+  }
+
+  return settings.baseUrl || getProviderBaseUrl(settings.provider);
 }
 
 function createNativeModel(settings: AISettings, modelId: string) {

--- a/apps/extension/src/services/ai-settings.ts
+++ b/apps/extension/src/services/ai-settings.ts
@@ -13,15 +13,16 @@ export async function buildAISettingsFromProvider(
   enabled: boolean,
 ): Promise<AISettings> {
   const stored = await getStoredAIProviderConfig(provider);
-  const finalModel = providerSupportsCustomModel(provider)
-    ? stored.customModel?.trim() || model || getDefaultModel(provider)
-    : model || getDefaultModel(provider);
+  const customModel = providerSupportsCustomModel(provider)
+    ? stored.customModel?.trim() || undefined
+    : undefined;
+  const finalModel = customModel || model || getDefaultModel(provider);
 
   const settings: AISettings = {
     enabled,
     provider,
     model: finalModel,
-    customModel: stored.customModel?.trim() || undefined,
+    customModel,
     apiKey: stored.apiKey?.trim() || '',
     baseUrl: stored.baseUrl?.trim() || getProviderBaseUrl(provider),
     extraHeaders: parseExtraHeaders(stored.extraHeaders),


### PR DESCRIPTION
## Summary
- Route AI tools through shared provider settings so OpenAI-compatible/custom providers work consistently.
- Add AI service verification and model refresh controls in Options.
- Keep autosave silent, validate extra headers JSON, and fix wrapped settings tabs layout.

## Test plan
- [x] `bunx nx run extension:lint`
- [x] `bunx nx run extension:build:chrome`

Generated with [Claude Code](https://claude.com/claude-code)